### PR TITLE
Adding support for constructors using java.lang.Object as arguments

### DIFF
--- a/src/main/java/com/cedarsoftware/util/io/JsonReader.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonReader.java
@@ -2768,6 +2768,10 @@ public class JsonReader implements Closeable
                 {
                     values[i] = new java.sql.Date(System.currentTimeMillis());
                 }
+                else if (argType == Object.class)
+                {
+                    values[i] = new Object();
+                }
                 else
                 {
                     values[i] = null;


### PR DESCRIPTION
This patch allows the instantiation of objects whose constructor takes java.lang.Object as arguments.
Maybe a more generic approach would be to inspect the argument type and use reflection to try to instantiate it. So for example, if the constructor is expecting an Object use reflection to get the java.lang.Object constructor and create an instante to pass to the constructor.
