### PR TITLE
Custom Reader for Root Objects without usable Constructor

### DIFF
--- a/src/test/java/com/cedarsoftware/util/io/Dog.java
+++ b/src/test/java/com/cedarsoftware/util/io/Dog.java
@@ -13,4 +13,18 @@ public class Dog
 
         public int getParentX() { return x; }
     }
+
+	public static class Shoe {
+		private Shoe(Leg leg) {
+			if (leg == null) {
+				throw new IllegalArgumentException(
+						"A Shoe without a leg ... what a pity");
+			}
+		}
+
+		public static Shoe construct() {
+			return new Shoe(new Dog().new Leg());
+		}
+
+	}
 }

--- a/src/test/java/com/cedarsoftware/util/io/TestJsonReaderWriter.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestJsonReaderWriter.java
@@ -1,15 +1,12 @@
 package com.cedarsoftware.util.io;
 
-import com.cedarsoftware.util.DeepEquals;
-import com.cedarsoftware.util.io.JsonWriter.JsonClassWriter;
-import com.google.gson.Gson;
-import org.junit.FixMethodOrder;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
-import org.junit.runners.MethodSorters;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.awt.Point;
 import java.io.ByteArrayInputStream;
@@ -53,13 +50,19 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.junit.runners.MethodSorters;
+
+import com.cedarsoftware.util.DeepEquals;
+import com.cedarsoftware.util.io.Dog.Shoe;
+import com.cedarsoftware.util.io.JsonReader.JsonClassReader;
+import com.cedarsoftware.util.io.JsonWriter.JsonClassWriter;
+import com.google.gson.Gson;
 
 /**
  * Test cases for JsonReader / JsonWriter
@@ -7059,5 +7062,37 @@ public class TestJsonReaderWriter
 		}
 
 		return o;
+	}
+
+	@Test
+	public void testCustomTopReaderShoe() throws IOException {
+		JsonReader.addReader(Shoe.class, new JsonClassReader() {
+
+			@Override
+			public Object read(Object jOb,
+					LinkedList<JsonObject<String, Object>> stack)
+					throws IOException {
+
+				// no need to do anything special
+				return Shoe.construct();
+			}
+		});
+		Shoe shoe = Shoe.construct();
+
+		// Dirty Workaround otherwise
+		Object[] array = new Object[1];
+		array[0] = shoe;
+		String workaroundString = JsonWriter.objectToJson(array);
+		JsonReader.jsonToJava(workaroundString);// shoe can be acessed by
+												// checking array type + length
+												// and acessing [0]
+
+		String json = JsonWriter.objectToJson(shoe);
+		//Should not fail, as we defined our own reader
+		// It is expected, that this object is instanciated twice:
+		// -once for analysis + Stack
+		// -deserialization with Stack
+		JsonReader.jsonToJava(json);
+
 	}
 }


### PR DESCRIPTION
@jdereg 

As I told you we had another problem concerning own custom reader.
As far as I understood, when an object is read, it is first instanciated for analysis purposes. Therefore all constructors are tried, but not a custom reader is used. This can cause problems so an array workaround can be used (see test).
I added the function, that also the custom readers are concerned for the instanciation of the root object.

I have also attached a test case which shows the problem, feel free to try it out. At this point the custom reader instanciates the object twice, once without stack (first time) and the second time with stack (this object should represent the deserialized one).

In my opinion it is also dangerous to try out every constructor with bogus values, as static calls (e.g. for business logic may be made). I would suggest to add a toggle for this feature, so it could be turned off.
