### PR TITLE
Handle the case where toString() fails during error reporting.

### DIFF
--- a/src/main/java/com/cedarsoftware/util/io/JsonReader.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonReader.java
@@ -1970,7 +1970,23 @@ public class JsonReader implements Closeable
         }
         catch (Exception e)
         {
-            error(e.getClass().getSimpleName() + " setting field '" + field.getName() + "' on target: " + target + " with value: " + rhs, e);
+            error(e.getClass().getSimpleName() + " setting field '" + field.getName() + "' on target: " + safeToString(target) + " with value: " + rhs, e);
+        }
+    }
+
+    private static String safeToString(Object o)
+    {
+        if (o == null)
+        {
+            return "null";
+        }
+        try
+        {
+            return o.toString();
+        }
+        catch (Exception e)
+        {
+            return o.getClass().toString();
         }
     }
 


### PR DESCRIPTION
In line 1973 we are reporting an error that happened while trying to initialize an object. Calling `toString()` on this object has a good chance of failing, and then the original error is not reported. I propose using the object's class name as a fallback when `toString()` fails.

The `== null` case is just for completeness.