### PR TITLE
Fixed bug: Identical objects in collection with customReader cause an

### DIFF
--- a/src/main/java/com/cedarsoftware/util/io/ObjectResolver.java
+++ b/src/main/java/com/cedarsoftware/util/io/ObjectResolver.java
@@ -279,9 +279,6 @@ class ObjectResolver extends Resolver
             else if ((special = readIfMatching(element, null, stack)) != null)
             {
                 col.add(special);
-                if(element instanceof JsonObject){
-                	((JsonObject) element).setTarget(special);
-                }
             }
             else if (element instanceof String || element instanceof Boolean || element instanceof Double || element instanceof Long)
             {    // Allow Strings, Booleans, Longs, and Doubles to be "inline" without Java object decoration (@id, @type, etc.)
@@ -551,7 +548,11 @@ class ObjectResolver extends Resolver
         {
             ((JsonObject)o).setType(c.getName());
         }
-        return closestReader.read(o, stack);
+        Object read = closestReader.read(o, stack);
+        if(isJsonObject){
+        	((JsonObject)o).setTarget(read);
+        }
+		return read;
     }
 
     private static void markUntypedObjects(final Type type, final Object rhs, final Map<String, Field> classFields)

--- a/src/main/java/com/cedarsoftware/util/io/ObjectResolver.java
+++ b/src/main/java/com/cedarsoftware/util/io/ObjectResolver.java
@@ -279,6 +279,9 @@ class ObjectResolver extends Resolver
             else if ((special = readIfMatching(element, null, stack)) != null)
             {
                 col.add(special);
+                if(element instanceof JsonObject){
+                	((JsonObject) element).setTarget(special);
+                }
             }
             else if (element instanceof String || element instanceof Boolean || element instanceof Double || element instanceof Long)
             {    // Allow Strings, Booleans, Longs, and Doubles to be "inline" without Java object decoration (@id, @type, etc.)

--- a/src/test/groovy/com/cedarsoftware/util/io/CustomReaderClass.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/CustomReaderClass.groovy
@@ -1,0 +1,14 @@
+package com.cedarsoftware.util.io
+
+class CustomReaderClass {
+
+	private String test;
+	
+	public void setTest(String test) {
+		this.test = test;
+	}
+	
+	public String getTest() {
+		return test;
+	}
+}

--- a/src/test/groovy/com/cedarsoftware/util/io/TestCustomReaderIdentity.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestCustomReaderIdentity.groovy
@@ -1,0 +1,73 @@
+package com.cedarsoftware.util.io
+
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.cedarsoftware.util.io.JsonReader.JsonClassReader;
+
+class TestCustomReaderIdentity {
+	@BeforeClass
+	public static void setUp(){
+		
+		JsonReader.addReader(CustomReaderClass.class,  new JsonClassReader() {
+			
+			@Override
+			public Object read(Object jOb, Deque<JsonObject<String, Object>> stack) {
+				CustomReaderClass customClass = new CustomReaderClass();
+				customClass.setTest("blab");
+				
+				return customClass;
+			}
+		});
+		
+	}
+	
+	
+	/**
+	 * This test uses a customReader to read two identical instances in a collection.
+	 * A customWriter is not necessary.
+	 */
+	@Test
+	public void testCustomReaderSerialization(){
+		
+		List<CustomReaderClass> elements = new LinkedList<>();
+		CustomReaderClass element = new CustomReaderClass();
+		element.setTest("hallo");
+		
+		elements.add(element);
+		elements.add(element);
+		
+		
+		String json = JsonWriter.objectToJson(elements);
+		
+		System.out.println(json);
+		
+		Object obj = JsonReader.jsonToJava(json);
+		
+	}
+	
+	/**
+	 * This test does not use a customReader to read two identical instances in a collection.
+	 * A customWriter is not necessary.
+	 */
+	@Test
+	public void testSerializationOld(){
+		List<WithoutCustomReaderClass> elements = new LinkedList<>();
+		WithoutCustomReaderClass element = new WithoutCustomReaderClass();
+		element.setTest("hallo");
+		
+		elements.add(element);
+		elements.add(element);
+		
+		
+		String json = JsonWriter.objectToJson(elements);
+		
+		System.out.println(json);
+		
+		Object obj = JsonReader.jsonToJava(json);
+	}
+}

--- a/src/test/groovy/com/cedarsoftware/util/io/TestCustomReaderIdentity.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestCustomReaderIdentity.groovy
@@ -1,5 +1,6 @@
 package com.cedarsoftware.util.io
 
+import java.lang.annotation.ElementType;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
@@ -44,7 +45,6 @@ class TestCustomReaderIdentity {
 		
 		String json = JsonWriter.objectToJson(elements);
 		
-		System.out.println(json);
 		
 		Object obj = JsonReader.jsonToJava(json);
 		
@@ -66,7 +66,43 @@ class TestCustomReaderIdentity {
 		
 		String json = JsonWriter.objectToJson(elements);
 		
-		System.out.println(json);
+		
+		Object obj = JsonReader.jsonToJava(json);
+	}
+	
+	@Test
+	public void testInSet(){
+		Set<WithoutCustomReaderClass> set = new HashSet<>();
+		
+		CustomReaderClass element = new CustomReaderClass();
+		element.setTest("hallo");
+		
+		WithoutCustomReaderClass e1 = new WithoutCustomReaderClass();
+		e1.setCustomReaderInner(element);
+		
+		WithoutCustomReaderClass e2 = new WithoutCustomReaderClass();
+		e2.setCustomReaderInner(element);
+		
+		set.add(e1);
+		set.add(e2);
+		
+		String json = JsonWriter.objectToJson(set);
+		
+		
+		Object obj = JsonReader.jsonToJava(json);
+	}
+	
+	@Test
+	public void testInArray(){
+		CustomReaderClass[] array = new CustomReaderClass[2];
+		CustomReaderClass element = new CustomReaderClass();
+		element.setTest("hallo");
+		
+		array[0] = element;
+		array[1] = element;
+		
+		String json = JsonWriter.objectToJson(array);
+		
 		
 		Object obj = JsonReader.jsonToJava(json);
 	}

--- a/src/test/groovy/com/cedarsoftware/util/io/WithoutCustomReaderClass.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/WithoutCustomReaderClass.groovy
@@ -1,0 +1,13 @@
+package com.cedarsoftware.util.io
+
+class WithoutCustomReaderClass {
+	private String test;
+	
+	public void setTest(String test) {
+		this.test = test;
+	}
+	
+	public String getTest() {
+		return test;
+	}
+}

--- a/src/test/groovy/com/cedarsoftware/util/io/WithoutCustomReaderClass.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/WithoutCustomReaderClass.groovy
@@ -2,6 +2,7 @@ package com.cedarsoftware.util.io
 
 class WithoutCustomReaderClass {
 	private String test;
+	private CustomReaderClass customReaderInner;
 	
 	public void setTest(String test) {
 		this.test = test;
@@ -9,5 +10,13 @@ class WithoutCustomReaderClass {
 	
 	public String getTest() {
 		return test;
+	}
+	
+	public void setCustomReaderInner(CustomReaderClass customReaderInner) {
+		this.customReaderInner = customReaderInner;
+	}
+	
+	public CustomReaderClass getCustomReaderInner() {
+		return customReaderInner;
 	}
 }


### PR DESCRIPTION
Hi @jdereg

we found the following Bug.
Using a CustomReader in a Collection with at least two identical elements causes an exception (don't have the stacktrace, see customReader serialization).

I've provided:

- testCase
- possible fix

Keep up the great job!

Cheers

Kai