### PR TITLE
Android pre KITKAT support

### DIFF
--- a/src/main/java/com/cedarsoftware/util/io/JsonObject.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonObject.java
@@ -2,6 +2,7 @@ package com.cedarsoftware.util.io;
 
 import java.lang.reflect.Array;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -33,12 +34,27 @@ import java.util.Map;
  */
 public class JsonObject<K, V> extends LinkedHashMap<K, V>
 {
+    static Map<String,String> primitiveWrappers = new HashMap<String, String>();
+
     Object target;
     boolean isMap = false;
     String type;
     long id = -1;
     int line;
     int col;
+
+    static
+    {
+        primitiveWrappers.put("boolean","java.lang.Boolean");
+        primitiveWrappers.put("byte","java.lang.Byte");
+        primitiveWrappers.put("char","java.lang.Character");
+        primitiveWrappers.put("double","java.lang.Double");
+        primitiveWrappers.put("float","java.lang.Float");
+        primitiveWrappers.put("int","java.lang.Integer");
+        primitiveWrappers.put("long","java.lang.Long");
+        primitiveWrappers.put("short","java.lang.Short");
+    }
+
 
     public long getId()
     {
@@ -81,16 +97,13 @@ public class JsonObject<K, V> extends LinkedHashMap<K, V>
         {
             return false;
         }
-        return type.equals("boolean") || type.equals("byte") || type.equals("char") || type.equals("double") || type.equals("float") ||
-                type.equals("int") || type.equals("long") || type.equals("short");
+        return primitiveWrappers.containsKey(type);
     }
 
     public static boolean isPrimitiveWrapper(Class c)
     {
         final String cname = c.getName();
-        return cname.equals("java.lang.Boolean") || cname.equals("java.lang.Byte") || cname.equals("java.lang.Character") ||
-                cname.equals("java.lang.Double") || cname.equals("java.lang.Float") || cname.equals("java.lang.Integer") ||
-                cname.equals("java.lang.Long") || cname.equals("java.lang.Short");
+        return primitiveWrappers.containsValue(cname);
     }
 
     public Object getPrimitiveValue()

--- a/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
+++ b/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
@@ -88,7 +88,7 @@ public class MetaUtils
             {
                 unsafe = new Unsafe();
             }
-            catch (ReflectiveOperationException e)
+            catch (InvocationTargetException e)
             {
                 useUnsafe = false;
             }
@@ -824,9 +824,9 @@ public class MetaUtils
 
         /**
          * Constructs unsafe object, acting as a wrapper.
-         * @throws ReflectiveOperationException
+         * @throws InvocationTargetException
          */
-        public Unsafe() throws ReflectiveOperationException
+        public Unsafe() throws InvocationTargetException
         {
             try
             {
@@ -838,7 +838,7 @@ public class MetaUtils
             }
             catch(Exception e)
             {
-                throw new ReflectiveOperationException(e);
+                throw new InvocationTargetException(e);
             }
         }
 


### PR DESCRIPTION
When I was testing lib on pre KITKAT devices, There is VerifyError because ReflectiveOperationException is supported from Android API 19, I made change to support oldest devices, replacing ReflectiveOperationException with InvocationTargetException helped.

I also added cleaner checking that type is primitive

```
07-02 14:51:10.236    3329-3329/x.x.x.x W/dalvikvm﹕ VFY: unable to resolve exception class 2683 (Ljava/lang/ReflectiveOperationException;)
07-02 14:51:10.236    3329-3329/x.x.x.x W/dalvikvm﹕ VFY: unable to find exception handler at addr 0xc
07-02 14:51:10.236    3329-3329/x.x.x.x W/dalvikvm﹕ VFY:  rejected Lcom/cedarsoftware/util/io/MetaUtils;.setUseUnsafe (Z)V
07-02 14:51:10.236    3329-3329/x.x.x.x W/dalvikvm﹕ VFY:  rejecting opcode 0x0d at 0x000c
07-02 14:51:10.236    3329-3329/x.x.x.x W/dalvikvm﹕ VFY:  rejected Lcom/cedarsoftware/util/io/MetaUtils;.setUseUnsafe (Z)V
07-02 14:51:10.236    3329-3329/x.x.x.x W/dalvikvm﹕ Verifier rejected class Lcom/cedarsoftware/util/io/MetaUtils;
07-02 14:51:10.236    3329-3329/x.x.x.x D/AndroidRuntime﹕ Shutting down VM
07-02 14:51:10.236    3329-3329/x.x.x.x W/dalvikvm﹕ threadid=1: thread exiting with uncaught exception (group=0x418d37d0)

07-02 14:51:10.236    3329-3329/x.x.x.x E/AndroidRuntime﹕ FATAL EXCEPTION: main
    java.lang.VerifyError: com/cedarsoftware/util/io/MetaUtils
            at com.cedarsoftware.util.io.JsonWriter.traceReferences(JsonWriter.java:628)
            at com.cedarsoftware.util.io.JsonWriter.write(JsonWriter.java:588)
            at com.cedarsoftware.util.io.JsonWriter.objectToJson(JsonWriter.java:235)
            at com.cedarsoftware.util.io.JsonWriter.objectToJson(JsonWriter.java:213)
            at pl.kalisz.kamil.preffer.serializer.JsonSerializer.serialize(JsonSerializer.java:16)
            at pl.kalisz.kamil.preffer.PrefferInvocationHandler.invoke(PrefferInvocationHandler.java:59)
            at $Proxy15.setPreferenceMigrated(Native Method)
            at com.finanteq.finance.preferences.migration.InvestGlobalPreferenceMigratorImpl.migrate(InvestGlobalPreferenceMigratorImpl.java:76)
            at com.finanteq.finance.preferences.migration.InvestGlobalPreferenceMigratorImpl.migrate(InvestGlobalPreferenceMigratorImpl.java:53)
            at x.x.x.x.ui.SplashScreen.migratePreferences(SplashScreen.java:168)
            at x.x.x.x.ui.SplashScreen.onResume(SplashScreen.java:163)
            at android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1184)
            at android.app.Activity.performResume(Activity.java:5082)
            at android.app.ActivityThread.performResumeActivity(ActivityThread.java:2566)
            at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:2604)
            at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2090)
            at android.app.ActivityThread.access$600(ActivityThread.java:130)
            at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1196)
            at android.os.Handler.dispatchMessage(Handler.java:99)
            at android.os.Looper.loop(Looper.java:137)
            at android.app.ActivityThread.main(ActivityThread.java:4747)
            at java.lang.reflect.Method.invokeNative(Native Method)
            at java.lang.reflect.Method.invoke(Method.java:511)
            at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:786)
            at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:553)
            at dalvik.system.NativeStart.main(Native Method)
```
