### PR TITLE
Check Object instead of declaration when no Type shall be written in serialization

### DIFF
--- a/src/main/java/com/cedarsoftware/util/io/JsonWriter.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonWriter.java
@@ -2075,7 +2075,8 @@ public class JsonWriter implements Closeable, Flushable
         Class type = field.getType();
         boolean forceType = o.getClass() != type;     // If types are not exactly the same, write "@type" field
 
-        if (MetaUtils.isPrimitive(type))
+        //When no type is written we can check the Object itself not the declaration
+        if (MetaUtils.isPrimitive(type) || (neverShowType && MetaUtils.isPrimitive(o.getClass())))
         {
             writePrimitive(o, false);
         }


### PR DESCRIPTION
when no type shall be written, we we can directly write primitives, if the value of the object is primitive.