### PR TITLE
Code quality fix - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".

### DIFF
--- a/src/main/java/com/cedarsoftware/util/io/JsonWriter.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonWriter.java
@@ -756,7 +756,7 @@ public class JsonWriter implements Closeable, Flushable
             return false;
         }
 
-        if (obj != null && MetaUtils.isLogicalPrimitive(obj.getClass()))
+        if (MetaUtils.isLogicalPrimitive(obj.getClass()))
         {
             return false;
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2583

Please let me know if you have any questions.

Faisal Hameed