### PR TITLE
General code quality fix-1

### DIFF
--- a/src/main/java/com/cedarsoftware/util/io/JsonObject.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonObject.java
@@ -170,7 +170,7 @@ public class JsonObject<K, V> extends LinkedHashMap<K, V>
     {
         if (containsKey("@items") && !containsKey("@keys"))
         {
-            return ((target instanceof Collection) || (type != null && !type.contains("[")));
+            return (target instanceof Collection || (type != null && !type.contains("[")));
         }
 
         return target instanceof Collection;

--- a/src/main/java/com/cedarsoftware/util/io/JsonParser.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonParser.java
@@ -401,7 +401,7 @@ class JsonParser
         }
         boolean isNeg = buffer[0] == '-';
         long n = 0;
-        for (int i = (isNeg ? 1 : 0); i < len; i++)
+        for (int i = isNeg ? 1 : 0; i < len; i++)
         {
             n = (buffer[i] - '0') + n * 10;
         }

--- a/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
+++ b/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
@@ -34,6 +34,8 @@ import java.util.regex.Pattern;
  */
 public class MetaUtils
 {
+    private MetaUtils () {}
+    
     private static final Map<Class, Map<String, Field>> classMetaCache = new ConcurrentHashMap<Class, Map<String, Field>>();
     private static final Set<Class> prims = new HashSet<Class>();
     private static final Map<String, Class> nameToClass = new HashMap<String, Class>();

--- a/src/main/java/com/cedarsoftware/util/io/ObjectResolver.java
+++ b/src/main/java/com/cedarsoftware/util/io/ObjectResolver.java
@@ -708,7 +708,7 @@ class ObjectResolver extends Resolver
     {
         if (t instanceof ParameterizedType)
         {
-            ParameterizedType pType = ((ParameterizedType) t);
+            ParameterizedType pType = (ParameterizedType) t;
 
             if (pType.getRawType() instanceof Class)
             {

--- a/src/main/java/com/cedarsoftware/util/io/Readers.java
+++ b/src/main/java/com/cedarsoftware/util/io/Readers.java
@@ -30,6 +30,8 @@ import java.util.regex.Pattern;
  */
 public class Readers
 {
+    private Readers () {}
+    
     private static final String days = "(monday|mon|tuesday|tues|tue|wednesday|wed|thursday|thur|thu|friday|fri|saturday|sat|sunday|sun)"; // longer before shorter matters
     private static final String mos = "(January|Jan|February|Feb|March|Mar|April|Apr|May|June|Jun|July|Jul|August|Aug|September|Sept|Sep|October|Oct|November|Nov|December|Dec)";
     private static final Pattern datePattern1 = Pattern.compile("(\\d{4})[./-](\\d{1,2})[./-](\\d{1,2})");

--- a/src/main/java/com/cedarsoftware/util/io/Writers.java
+++ b/src/main/java/com/cedarsoftware/util/io/Writers.java
@@ -36,6 +36,8 @@ import java.util.TimeZone;
  */
 public class Writers
 {
+    private Writers () {}
+    
     public static class TimeZoneWriter implements JsonWriter.JsonClassWriter
     {
         public void write(Object obj, boolean showType, Writer output) throws IOException


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
 
Please let me know if you have any questions.

Faisal Hameed