### PR TITLE
#76 Add support to allow easily reading the current object in a custo…

### DIFF
--- a/src/main/java/com/cedarsoftware/util/io/JsonReader.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonReader.java
@@ -57,6 +57,7 @@ public class JsonReader implements Closeable
     public static final String USE_MAPS = "USE_MAPS";                   // If set, the read-in JSON will be turned into a Map of Maps (JsonObject) representation
     public static final String UNKNOWN_OBJECT = "UNKNOWN_OBJECT";       // What to do when an object is found and 'type' cannot be determined.
     public static final String JSON_READER = "JSON_READER";             // Pointer to 'this' (automatically placed in the Map)
+    public static final String OBJECT_RESOLVER = "OBJECT_RESOLVER";     // Pointer to the current ObjectResolver (automatically placed in the Map)
     public static final String TYPE_NAME_MAP = "TYPE_NAME_MAP";         // If set, this map will be used when writing @type values - allows short-hand abbreviations type names
     static final String TYPE_NAME_MAP_REVERSE = "TYPE_NAME_MAP_REVERSE";// This map is the reverse of the TYPE_NAME_MAP (value -> key)
     protected final ConcurrentMap<Class, JsonClassReaderBase> readers = new ConcurrentHashMap<Class, JsonClassReaderBase>();

--- a/src/main/java/com/cedarsoftware/util/io/MapResolver.java
+++ b/src/main/java/com/cedarsoftware/util/io/MapResolver.java
@@ -51,7 +51,13 @@ public class MapResolver extends Resolver
         super(reader);
     }
 
-    protected void traverseFields(final Deque<JsonObject<String, Object>> stack, final JsonObject<String, Object> jsonObj)
+    protected Object readIfMatching(Object o, Class compType, Deque<JsonObject<String, Object>> stack)
+    {
+        // No custom reader support for maps
+        return null;
+    }
+
+    public void traverseFields(final Deque<JsonObject<String, Object>> stack, final JsonObject<String, Object> jsonObj)
     {
         final Object target = jsonObj.target;
         for (Map.Entry<String, Object> e : jsonObj.entrySet())

--- a/src/main/java/com/cedarsoftware/util/io/ObjectResolver.java
+++ b/src/main/java/com/cedarsoftware/util/io/ObjectResolver.java
@@ -44,7 +44,7 @@ import java.util.*;
  *         See the License for the specific language governing permissions and
  *         limitations under the License.
  */
-class ObjectResolver extends Resolver
+public class ObjectResolver extends Resolver
 {
     protected ObjectResolver(JsonReader reader)
     {
@@ -58,15 +58,8 @@ class ObjectResolver extends Resolver
      * @param stack   Stack (Deque) used for graph traversal.
      * @param jsonObj a Map-of-Map representation of the current object being examined (containing all fields).
      */
-    protected void traverseFields(final Deque<JsonObject<String, Object>> stack, final JsonObject<String, Object> jsonObj)
+    public void traverseFields(final Deque<JsonObject<String, Object>> stack, final JsonObject<String, Object> jsonObj)
     {
-        Object special;
-        if ((special = readIfMatching(jsonObj, null, stack)) != null)
-        {
-            jsonObj.target = special;
-            return;
-        }
-
         final Object javaMate = jsonObj.target;
         final Iterator<Map.Entry<String, Object>> i = jsonObj.entrySet().iterator();
         final Class cls = javaMate.getClass();

--- a/src/main/java/com/cedarsoftware/util/io/Resolver.java
+++ b/src/main/java/com/cedarsoftware/util/io/Resolver.java
@@ -79,6 +79,7 @@ abstract class Resolver
     {
         this.reader = reader;
         Map optionalArgs = reader.getArgs();
+        optionalArgs.put(JsonReader.OBJECT_RESOLVER, this);
         useMaps = Boolean.TRUE.equals(optionalArgs.get(JsonReader.USE_MAPS));
         unknownClass = optionalArgs.containsKey(JsonReader.UNKNOWN_OBJECT) ? optionalArgs.get(JsonReader.UNKNOWN_OBJECT) : null;
     }
@@ -121,13 +122,23 @@ abstract class Resolver
             }
             else
             {
-                traverseFields(stack, jsonObj);
+                Object special;
+                if ((special = readIfMatching(jsonObj, null, stack)) != null)
+                {
+                    jsonObj.target = special;
+                }
+                else
+                {
+                    traverseFields(stack, jsonObj);
+                }
             }
         }
         return root.target;
     }
 
-    protected abstract void traverseFields(Deque<JsonObject<String, Object>> stack, JsonObject<String, Object> jsonObj);
+    protected abstract Object readIfMatching(final Object o, final Class compType, final Deque<JsonObject<String, Object>> stack);
+
+    public abstract void traverseFields(Deque<JsonObject<String, Object>> stack, JsonObject<String, Object> jsonObj);
 
     protected abstract void traverseCollection(Deque<JsonObject<String, Object>> stack, JsonObject<String, Object> jsonObj);
 

--- a/src/test/groovy/com/cedarsoftware/util/io/TestCustomReaderObject.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestCustomReaderObject.groovy
@@ -1,0 +1,47 @@
+package com.cedarsoftware.util.io
+
+import org.junit.Test
+
+/**
+ * @author John DeRegnaucourt (jdereg@gmail.com)
+ *         <br>
+ *         Copyright (c) Cedar Software LLC
+ *         <br><br>
+ *         Licensed under the Apache License, Version 2.0 (the "License")
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *         <br><br>
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *         <br><br>
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ */
+class TestCustomReaderObject
+{
+
+	static class CustomReader implements JsonReader.JsonClassReaderEx {
+
+		@Override
+		public Object read(Object jOb, Deque<JsonObject<String, Object>> stack, Map<String, Object> args) {
+			ObjectResolver resolver = (ObjectResolver) args.get(JsonReader.OBJECT_RESOLVER);
+			resolver.traverseFields(stack, (JsonObject<String, Object>) jOb);
+			Object target = ((JsonObject<String, Object>) jOb).getTarget();
+			return target;
+		}
+	}
+
+	/**
+	 * This test uses a customReader to read the entire object.
+	 */
+	@Test
+	public void testCustomReaderSerialization()
+	{
+		TestCustomWriter.Person p = TestCustomWriter.createTestPerson();
+		String json = JsonWriter.objectToJson(p);
+		TestCustomWriter.Person pRead = TestUtil.readJsonObject(json, [(CustomDataClass.class):new CustomReader()]) as TestCustomWriter.Person
+		assert p.equals(pRead)
+	}
+}

--- a/src/test/groovy/com/cedarsoftware/util/io/TestCustomWriter.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestCustomWriter.groovy
@@ -186,7 +186,7 @@ class TestCustomWriter
         }
     }
 
-    Person createTestPerson()
+    static Person createTestPerson()
     {
         Person p = new Person()
         p.firstName = 'Michael'
@@ -196,7 +196,7 @@ class TestCustomWriter
         return p
     }
 
-    Pet createPet(String name, String type, int age)
+    static Pet createPet(String name, String type, int age)
     {
         Pet pet = new Pet()
         pet.name = name


### PR DESCRIPTION
This separates out means of easily reading a full object from previous pull request where it was combined with the other two issues. For a use case, you can see this code: https://github.com/Talend/daikon/tree/master/daikon/src/main/java/org/talend/daikon/serialize.

Our code is intended to provide a general purpose means of serializing and deserializing Java objects for storage with a means to migrate from older versions of the serialized objects. This change to json-io is essential to handle that - by providing a means of writing a version number separate from the object. It is hoped that people will find it generally useful to be able to write (and read) the current object using your normal serialization, but also be able to augment it in various ways.