### PR TITLE
Return correct wrapper values for double and long fields

### DIFF
--- a/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
+++ b/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
@@ -740,7 +740,7 @@ public class MetaUtils
                     }
                     return Double.parseDouble((String) rhs);
                 }
-                return rhs != null ? rhs : 0.0d;
+                return rhs != null ? ((Number) rhs).doubleValue() : 0.0d;
             }
             else if (cname.equals("float") || cname.equals("java.lang.Float"))
             {
@@ -779,7 +779,7 @@ public class MetaUtils
                     }
                     return Long.parseLong((String) rhs);
                 }
-                return rhs != null ? rhs : 0L;
+                return rhs != null ? ((Number) rhs).longValue() : 0L;
             }
             else if (cname.equals("short") || cname.equals("java.lang.Short"))
             {


### PR DESCRIPTION
I have an issue where JSON-IO fails to set an double field, when JSON from the client contains a whole number (e.g. 300) instead of a decimal (e.g. 300.0). I tracked it down to those two lines.