### PR TITLE
Create Reader option that when turned on, fails Json reading when a class in @type is not valid.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ can be read, modified, and then re-written by a JVM that does not contain any of
                             // will be set on it. Set to false, and an exception will be 
                             // thrown when an unknown object type is encountered.  The 
                             // location in the JSON will be given.
+    FAIL_ON_UNKNOWN_TYPE    // Set to Boolean.TRUE to have JSON reader throw JsonIoException
+                            // when a @type value references a class that is not loadable
+                            // from the class loader. Set to any other value (or leave out)
+                            // and JSON parsing will return a Map to represent the unknown
+                            // object defined by the invalid @type value.
     CLASSLOADER             // ClassLoader instance to use when turning String names of     
                             // classes into JVM Class instances.
       

--- a/src/main/java/com/cedarsoftware/util/io/JsonReader.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonReader.java
@@ -60,6 +60,8 @@ public class JsonReader implements Closeable
     public static final String USE_MAPS = "USE_MAPS";
     /** What to do when an object is found and 'type' cannot be determined. */
     public static final String UNKNOWN_OBJECT = "UNKNOWN_OBJECT";
+    /** Will fail JSON parsing if 'type' class defined but is not on classpath. */
+    public static final String FAIL_ON_UNKNOWN_TYPE = "FAIL_ON_UNKNOWN_TYPE";
     /** Pointer to 'this' (automatically placed in the Map) */
     public static final String JSON_READER = "JSON_READER";
     /** Pointer to the current ObjectResolver (automatically placed in the Map) */

--- a/src/main/java/com/cedarsoftware/util/io/Resolver.java
+++ b/src/main/java/com/cedarsoftware/util/io/Resolver.java
@@ -40,6 +40,7 @@ abstract class Resolver
     private final Collection<Object[]> prettyMaps = new ArrayList<Object[]>();
     private final boolean useMaps;
     private final Object unknownClass;
+    private final boolean failOnUnknownType;
 
     /**
      * UnresolvedReference is created to hold a logical pointer to a reference that
@@ -82,6 +83,7 @@ abstract class Resolver
         optionalArgs.put(JsonReader.OBJECT_RESOLVER, this);
         useMaps = Boolean.TRUE.equals(optionalArgs.get(JsonReader.USE_MAPS));
         unknownClass = optionalArgs.containsKey(JsonReader.UNKNOWN_OBJECT) ? optionalArgs.get(JsonReader.UNKNOWN_OBJECT) : null;
+        failOnUnknownType = Boolean.TRUE.equals(optionalArgs.get(JsonReader.FAIL_ON_UNKNOWN_TYPE));
     }
 
     protected JsonReader getReader()
@@ -269,7 +271,7 @@ abstract class Resolver
             Class c;
             try
             {
-                c = MetaUtils.classForName(type, reader.getClassLoader());
+                c = MetaUtils.classForName(type, reader.getClassLoader(), failOnUnknownType);
             }
             catch (Exception e)
             {

--- a/src/test/groovy/com/cedarsoftware/util/io/TestClassForName.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestClassForName.groovy
@@ -26,7 +26,7 @@ import static org.junit.Assert.fail
 class TestClassForName
 {
     @Test
-    void testInstantiation()
+    void testClassForName()
     {
         Class testObjectClass = MetaUtils.classForName('com.cedarsoftware.util.io.TestObject', TestClassForName.class.getClassLoader())
         assert testObjectClass instanceof Class
@@ -34,7 +34,7 @@ class TestClassForName
     }
 
     @Test
-    void testInstantiationWithClassloader()
+    void testClassForNameWithClassloader()
     {
         Class testObjectClass = MetaUtils.classForName('ReallyLong', new AlternateNameClassLoader('ReallyLong', Long.class))
         assert testObjectClass instanceof Class
@@ -42,7 +42,7 @@ class TestClassForName
     }
 
     @Test
-    void testClassForNameErrorHandling()
+    void testClassForNameNullClassErrorHandling()
     {
         try
         {
@@ -54,6 +54,25 @@ class TestClassForName
         }
 
         assert Map.class.isAssignableFrom(MetaUtils.classForName('Smith&Wesson', TestClassForName.class.getClassLoader()))
+    }
+
+    @Test
+    void testClassForNameFailOnClassLoaderErrorTrue()
+    {
+        try {
+            MetaUtils.classForName('foo.bar.baz.Qux', TestClassForName.class.getClassLoader(), true)
+            fail()
+        }
+        catch (JsonIoException expected) {
+        }
+    }
+
+    @Test
+    void testClassForNameFailOnClassLoaderErrorFalse()
+    {
+        Class testObjectClass = MetaUtils.classForName('foo.bar.baz.Qux', TestClassForName.class.getClassLoader(), false)
+        assert testObjectClass instanceof Class
+        assert 'java.util.LinkedHashMap' == testObjectClass.name
     }
 
     private class AlternateNameClassLoader extends ClassLoader {

--- a/src/test/groovy/com/cedarsoftware/util/io/TestUnknownObjectType.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestUnknownObjectType.groovy
@@ -2,6 +2,8 @@ package com.cedarsoftware.util.io
 
 import org.junit.Test
 
+import static org.junit.Assert.fail
+
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
  *         <br>
@@ -38,5 +40,26 @@ class TestUnknownObjectType
         def java = JsonReader.jsonToJava(json)
         assert java instanceof Map
         assert java.name == 'Joe'
+    }
+
+    @Test
+    void testUnknownClassTypePassesWhenFailOptionFalse()
+    {
+        def json = '{"@type":"foo.bar.baz.Qux", "name":"Joe"}'
+        def java = JsonReader.jsonToJava(json, [(JsonReader.FAIL_ON_UNKNOWN_TYPE): false ])
+        assert java instanceof Map
+        assert java.name == 'Joe'
+    }
+
+    @Test
+    void testUnknownClassTypeFailsWhenFailOptionTrue()
+    {
+        def json = '{"@type":"foo.bar.baz.Qux", "name":"Joe"}'
+        try {
+            JsonReader.jsonToJava(json, [(JsonReader.FAIL_ON_UNKNOWN_TYPE): true ])
+            fail()
+        }
+        catch (JsonIoException expected) {
+        }
     }
 }


### PR DESCRIPTION
We have had several instances during our development while using json-io where a Class was defined in the json via a @type value but was not accessible to the ClassLoader used to load the Class.  This usually manifests itself as a ClassCastException elsewhere in our app when we try to cast back the parsed json object.  At that point it can be difficult to debug what actual @type caused the failure.  We wanted an option to fast fail on parsing @types it can't resolve and not do the default LinkedHashMap behavior.  This request is an attempt at providing this option.  When the option is omitted or set to false the code behaves just like it did before.

This is more prevalent for us because we use the newly added CLASSLOADER option w/ ClassLoaders that have varying visibility into our objects.