### PR TITLE
only one initialization for all run

### DIFF
--- a/src/main/java/com/cedarsoftware/util/io/JsonReader.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonReader.java
@@ -78,6 +78,23 @@ public class JsonReader implements Closeable
     /** This map is the reverse of the TYPE_NAME_MAP (value ==> key) */
     static final String TYPE_NAME_MAP_REVERSE = "TYPE_NAME_MAP_REVERSE";
 
+    private static final Map<Class, JsonClassReaderBase> BASE_READERS = Collections.unmodifiableMap(new HashMap<Class, JsonClassReaderBase>() {{
+        put(String.class, new Readers.StringReader());
+        put(Date.class, new Readers.DateReader());
+        put(AtomicBoolean.class, new Readers.AtomicBooleanReader());
+        put(AtomicInteger.class, new Readers.AtomicIntegerReader());
+        put(AtomicLong.class, new Readers.AtomicLongReader());
+        put(BigInteger.class, new Readers.BigIntegerReader());
+        put(BigDecimal.class, new Readers.BigDecimalReader());
+        put(java.sql.Date.class, new Readers.SqlDateReader());
+        put(Timestamp.class, new Readers.TimestampReader());
+        put(Calendar.class, new Readers.CalendarReader());
+        put(TimeZone.class, new Readers.TimeZoneReader());
+        put(Locale.class, new Readers.LocaleReader());
+        put(Class.class, new Readers.ClassReader());
+        put(StringBuilder.class, new Readers.StringBuilderReader());
+        put(StringBuffer.class, new Readers.StringBufferReader());
+    }});
     protected final ConcurrentMap<Class, JsonClassReaderBase> readers = new ConcurrentHashMap<Class, JsonClassReaderBase>();
     protected MissingFieldHandler missingFieldHandler;
     protected final Set<Class> notCustom = new HashSet<Class>();
@@ -88,21 +105,7 @@ public class JsonReader implements Closeable
     private final Map<String, Object> args = new HashMap<String, Object>();
 
     {
-        addReader(String.class, new Readers.StringReader());
-        addReader(Date.class, new Readers.DateReader());
-        addReader(AtomicBoolean.class, new Readers.AtomicBooleanReader());
-        addReader(AtomicInteger.class, new Readers.AtomicIntegerReader());
-        addReader(AtomicLong.class, new Readers.AtomicLongReader());
-        addReader(BigInteger.class, new Readers.BigIntegerReader());
-        addReader(BigDecimal.class, new Readers.BigDecimalReader());
-        addReader(java.sql.Date.class, new Readers.SqlDateReader());
-        addReader(Timestamp.class, new Readers.TimestampReader());
-        addReader(Calendar.class, new Readers.CalendarReader());
-        addReader(TimeZone.class, new Readers.TimeZoneReader());
-        addReader(Locale.class, new Readers.LocaleReader());
-        addReader(Class.class, new Readers.ClassReader());
-        addReader(StringBuilder.class, new Readers.StringBuilderReader());
-        addReader(StringBuffer.class, new Readers.StringBufferReader());
+        readers.putAll(BASE_READERS);
     }
 
     static
@@ -256,6 +259,7 @@ public class JsonReader implements Closeable
          * @param c Map interface that was requested for instantiation.
          * @return a concrete Map type.
          */
+        @Override
         public Object newInstance(Class c)
         {
             if (SortedMap.class.isAssignableFrom(c))

--- a/src/main/java/com/cedarsoftware/util/io/JsonWriter.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonWriter.java
@@ -90,6 +90,23 @@ public class JsonWriter implements Closeable, Flushable
     /** If set, use the specified ClassLoader */
     public static final String CLASSLOADER = "CLASSLOADER";
 
+    private static final Map<Class, JsonClassWriterBase> BASE_WRITERS = Collections.unmodifiableMap(new HashMap<Class, JsonClassWriterBase>(){{
+        put(String.class, new Writers.JsonStringWriter());
+        put(Date.class, new Writers.DateWriter());
+        put(AtomicBoolean.class, new Writers.AtomicBooleanWriter());
+        put(AtomicInteger.class, new Writers.AtomicIntegerWriter());
+        put(AtomicLong.class, new Writers.AtomicLongWriter());
+        put(BigInteger.class, new Writers.BigIntegerWriter());
+        put(BigDecimal.class, new Writers.BigDecimalWriter());
+        put(java.sql.Date.class, new Writers.DateWriter());
+        put(Timestamp.class, new Writers.TimestampWriter());
+        put(Calendar.class, new Writers.CalendarWriter());
+        put(TimeZone.class, new Writers.TimeZoneWriter());
+        put(Locale.class, new Writers.LocaleWriter());
+        put(Class.class, new Writers.ClassWriter());
+        put(StringBuilder.class, new Writers.StringBuilderWriter());
+        put(StringBuffer.class, new Writers.StringBufferWriter());
+    }});
     private final ConcurrentMap<Class, JsonClassWriterBase> writers = new ConcurrentHashMap<Class, JsonClassWriterBase>();
     private final ConcurrentMap<Class, JsonClassWriterBase> writerCache = new ConcurrentHashMap<Class, JsonClassWriterBase>();
     private final Set<Class> notCustom = new HashSet<Class>();
@@ -114,21 +131,7 @@ public class JsonWriter implements Closeable, Flushable
     final Map<String, Object> args = new HashMap<String, Object>();
 
     {   // Add customer writers (these make common classes more succinct)
-        addWriter(String.class, new Writers.JsonStringWriter());
-        addWriter(Date.class, new Writers.DateWriter());
-        addWriter(AtomicBoolean.class, new Writers.AtomicBooleanWriter());
-        addWriter(AtomicInteger.class, new Writers.AtomicIntegerWriter());
-        addWriter(AtomicLong.class, new Writers.AtomicLongWriter());
-        addWriter(BigInteger.class, new Writers.BigIntegerWriter());
-        addWriter(BigDecimal.class, new Writers.BigDecimalWriter());
-        addWriter(java.sql.Date.class, new Writers.DateWriter());
-        addWriter(Timestamp.class, new Writers.TimestampWriter());
-        addWriter(Calendar.class, new Writers.CalendarWriter());
-        addWriter(TimeZone.class, new Writers.TimeZoneWriter());
-        addWriter(Locale.class, new Writers.LocaleWriter());
-        addWriter(Class.class, new Writers.ClassWriter());
-        addWriter(StringBuilder.class, new Writers.StringBuilderWriter());
-        addWriter(StringBuffer.class, new Writers.StringBufferWriter());
+        writers.putAll(BASE_WRITERS);
     }
 
     static


### PR DESCRIPTION
Hi,

avoid instantaciation of all "base" classes on each initialization of JsonReader (and Writer)