### PR TITLE
fix(migration): always notify handler

### DIFF
--- a/src/main/java/com/cedarsoftware/util/io/ObjectResolver.java
+++ b/src/main/java/com/cedarsoftware/util/io/ObjectResolver.java
@@ -87,7 +87,7 @@ public class ObjectResolver extends Resolver
             else if (missingFieldHandler != null)
             {
                 handleMissingField(stack, jsonObj, rhs, key);
-            }
+            }//else no handler so ignor.
         }
     }
 
@@ -267,7 +267,7 @@ public class ObjectResolver extends Resolver
             else if (rhs.getClass().isArray())
             {
                 // impossible to determine the array type.
-                // so ignore it.
+                storeMissingField(target, missingField, null);
             }
             else if (rhs instanceof JsonObject)
             {
@@ -277,11 +277,7 @@ public class ObjectResolver extends Resolver
                 if (ref != null)
                 { // Correct field references
                     final JsonObject refObject = getReferencedObj(ref);
-
-                    if (refObject.target != null)
-                    {
-                        storeMissingField(target, missingField, refObject.target);
-                    } // else unresolved ref so ignore it
+                    storeMissingField(target, missingField, refObject.target);
                 }
                 else
                 {   // Assign ObjectMap's to Object (or derived) fields
@@ -294,7 +290,11 @@ public class ObjectResolver extends Resolver
                             stack.addFirst((JsonObject) rhs);
                         }
                         storeMissingField(target, missingField, createJavaObjectInstance);
-                    } // else no type found so ignore it.
+                    } 
+                    else //no type found, just notify.
+                    {
+                        storeMissingField(target, missingField, null);
+                    }
                 }
             }
             else

--- a/src/main/java/com/cedarsoftware/util/io/Resolver.java
+++ b/src/main/java/com/cedarsoftware/util/io/Resolver.java
@@ -207,6 +207,7 @@ abstract class Resolver
         handleMissingFields();
     }
 
+    // calls the missing field handler if any for each recorded missing field.
     private void handleMissingFields()
     {
         MissingFieldHandler missingFieldHandler = reader.getMissingFieldHandler();

--- a/src/test/groovy/com/cedarsoftware/util/io/TestMissingFieldHandler.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestMissingFieldHandler.groovy
@@ -65,7 +65,7 @@ class TestMissingFieldHandler
         //        short s
         //        Short ss
         //        public String[] aStringArray
-        //        public Object[] aObjectArray
+        //        public Inner2 inner2WithNoSerializedType
         //those new fields are  only used to store the missing field callback result
         public Inner2 inner2Missing
         public long aLongMissing
@@ -89,8 +89,8 @@ class TestMissingFieldHandler
         Short ssMissing
     }
 
-    private static final String OLD_CUSTOM_POINT = '{"@type":"com.cedarsoftware.util.io.TestMissingFieldHandler$CustomPoint","x":5,"y":7}'
-    private static final String OLD_CUSTOM_POINT2 = '{"@type":"com.cedarsoftware.util.io.TestMissingFieldHandler$CustomPointWithRef","inner1":{"@id":1},"inner2":{"@type":"com.cedarsoftware.util.io.TestMissingFieldHandler$CustomPointWithRef$Inner2","inner12":{"@ref":1}},"b":true,"bb":true,"by":9,"bby":9,"c":"9","cc":"9","d":9.0,"dd":9.0,"f":9.0,"ff":9.0,"i":9,"ii":9,"l":9,"ll":9,"s":9,"ss":9,"aStringArray":["foo","bar"],"aObjectArray":[{"@type":"com.cedarsoftware.util.io.TestMissingFieldHandler$CustomPointWithRef$Inner1"},{"@type":"com.cedarsoftware.util.io.TestMissingFieldHandler$CustomPointWithRef$Inner2","inner12":null}]}'
+    private static final String OLD_CUSTOM_POINT = '{"@type":"com.cedarsoftware.util.io.TestMissingFieldHandler$CustomPoint","x":5,"y":7}';
+    private static final String OLD_CUSTOM_POINT2 = '{"@type":"com.cedarsoftware.util.io.TestMissingFieldHandler$CustomPointWithRef","inner1":{"@id":1},"inner2":{"@type":"com.cedarsoftware.util.io.TestMissingFieldHandler$CustomPointWithRef$Inner2","inner12":{"@ref":1}},"b":true,"bb":true,"by":9,"bby":9,"c":"9","cc":"9","d":9.0,"dd":9.0,"f":9.0,"ff":9.0,"i":9,"ii":9,"l":9,"ll":9,"s":9,"ss":9,"aStringArray":["foo","bar"],"inner2WithNoSerializedType":{"inner12":null}}';
 
     @Test
     void testMissingHandler()
@@ -136,9 +136,10 @@ class TestMissingFieldHandler
         //        pt.inner2 = new CustomPointWithRef.Inner2()
         //        pt.inner2.inner12 = pt.inner1
         //        pt.aStringArray = ["foo", "bar"]
+        //        pt.inner2WithNoSerializedType = new CustomPointWithRef.Inner2()
         //        println( JsonWriter.objectToJson(pt))
-        //        println( JsonWriter.objectToJson(pt))
-
+        def isStringArrayOk = false
+        def isInner2WithNoSerializedTypeOk = false
         JsonReader.MissingFieldHandler missingHandler = new JsonReader.MissingFieldHandler() {
             void fieldMissing(Object object, String fieldName, Object value)
             {
@@ -196,7 +197,10 @@ class TestMissingFieldHandler
                         ((CustomPointWithRef) object).ssMissing = (Short) value
                         break
                     case "aStringArray":
-                        ((CustomPointWithRef) object).aStringArrayMissing = (String[]) value
+                        isStringArrayOk = value == null
+                        break
+                    case "inner2WithNoSerializedType" :
+                        isInner2WithNoSerializedTypeOk = value == null
                         break
                 }
             }
@@ -220,6 +224,7 @@ class TestMissingFieldHandler
         assertTrue(clonePoint.llMissing == 9)
         assertTrue(clonePoint.sMissing == 9)
         assertTrue(clonePoint.ssMissing == 9)
-        assertNull(clonePoint.aStringArrayMissing)//arrays cannot be deserialized
+        assertTrue(isStringArrayOk)
+        assertTrue(isInner2WithNoSerializedTypeOk)
     }
 }


### PR DESCRIPTION
There was a regression in the last commit to improve the migration process.
Unrecoverable fields where ignored from the missing field notification.
With this commit the notification is done as before that is even when the deserialization cannot reconstruct the field value.