### PR TITLE
Use context class loader in JavaEE projects

### DIFF
--- a/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
+++ b/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
@@ -63,7 +63,7 @@ import static java.lang.reflect.Modifier.isPublic;
 public class MetaUtils
 {
     private MetaUtils () {}
-    
+
     private static final Map<Class, Map<String, Field>> classMetaCache = new ConcurrentHashMap<Class, Map<String, Field>>();
     private static final Set<Class> prims = new HashSet<Class>();
     private static final Map<String, Class> nameToClass = new HashMap<String, Class>();
@@ -420,7 +420,11 @@ public class MetaUtils
         Class currentClass = null;
         if (null == primitiveArray)
         {
-            currentClass = classLoader.loadClass(className);
+          try {
+              currentClass = classLoader.loadClass(className);
+          } catch (ClassNotFoundException e) {
+              currentClass = Thread.currentThread().getContextClassLoader().loadClass(className);
+          }
         }
 
         if (arrayType)

--- a/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
+++ b/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
@@ -63,7 +63,6 @@ import static java.lang.reflect.Modifier.isPublic;
 public class MetaUtils
 {
     private MetaUtils () {}
-
     private static final Map<Class, Map<String, Field>> classMetaCache = new ConcurrentHashMap<Class, Map<String, Field>>();
     private static final Set<Class> prims = new HashSet<Class>();
     private static final Map<String, Class> nameToClass = new HashMap<String, Class>();


### PR DESCRIPTION
When Json-io is used in JavaEE project as dependency to the one of the EJB module and the main project also have a Web module which compiles into *.war file in some cases library can't deserialize objects which is located in .*war package because JsonReader gets an instance of EarLibClassLoader that can only load class within /lib directory, but classes from *.war package after deploy are located in /WEB-INF directory. Sometimes classes from WAR module can't be moved into another module that compiles into jar file, so to deserilize those objects you can obtain context classloader, that as for instance WebAppClassLoader can load classes within /WEB-INF directory.