### PR TITLE
WIP Features/get as flat structure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <version.groovy>2.4.12</version.groovy>                  <!-- only test dependency -->
         <version.gson>2.6.2</version.gson>                      <!-- only test dependency -->
         <version.jmh>1.17.1</version.jmh>                       <!-- only test dependency -->
-        <version.java>1.6</version.java>
+        <version.java>1.8</version.java>
         <version.plugin.compiler>3.5.1</version.plugin.compiler>
         <version.plugin.deploy>2.8.2</version.plugin.deploy>
         <version.plugin.nexus>1.6.6</version.plugin.nexus>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <version.groovy>2.4.12</version.groovy>                  <!-- only test dependency -->
         <version.gson>2.6.2</version.gson>                      <!-- only test dependency -->
         <version.jmh>1.17.1</version.jmh>                       <!-- only test dependency -->
-        <version.java>1.8</version.java>
+        <version.java>1.7</version.java>
         <version.plugin.compiler>3.5.1</version.plugin.compiler>
         <version.plugin.deploy>2.8.2</version.plugin.deploy>
         <version.plugin.nexus>1.6.6</version.plugin.nexus>

--- a/src/main/java/com/cedarsoftware/util/io/JsonWriter.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonWriter.java
@@ -117,6 +117,9 @@ public class JsonWriter implements Closeable, Flushable
     private final Map<Object, Long> objVisited = new IdentityHashMap<Object, Long>();
     private final Map<Object, Long> objsReferenced = new IdentityHashMap<Object, Long>();
     private final StringBuilder out;
+	 // If we want a flat structure, we enclose the map in a JSON object body,
+	 // We need a different ouput to prevent objects from being written in reverse discovering order :
+    private final StringBuilder outFlat;
     private Map<String, String> typeNameMap = null;
     private boolean shortMetaKeys = false;
     private boolean neverShowType = false;
@@ -487,6 +490,7 @@ public class JsonWriter implements Closeable, Flushable
 //       }
 
 		this.out = new StringBuilder();
+		this.outFlat = new StringBuilder();
     }
 
     /**
@@ -815,6 +819,8 @@ public class JsonWriter implements Closeable, Flushable
       	  
       	  if(isFlatStructure){
       		  // If we want a flat structure, we enclose the map in a JSON object body :
+      		  // To prevent objects from being written in reverse discovering order :
+      		  output.append(this.outFlat);
       		  output.insert(0, '{').append('}');
       	  }
         }
@@ -1141,21 +1147,21 @@ public class JsonWriter implements Closeable, Flushable
         }
         else
         {
+      	  
             StringBuilder sb = getWrittenObject(obj, showType, false);
             if(!isFlatStructure){
             	 // Default behavior :
             	output.append(sb);
             }else{
             	// If we want a flat structure :
-            	if(output.length() == 0){
-            		output.insert(0, sb);
+            	// To prevent objects from being written in reverse discovering order :
+             	if(output.length() == 0){
+             		this.outFlat.insert(0, sb);
             	}else{
-            		output.insert(0, sb.append(','));
+            		this.outFlat.insert(0, sb.insert(0,','));
             		writeOptionalReference(obj, output);
             	}
             }
-            
-            
             
         }
     }

--- a/src/main/java/com/cedarsoftware/util/io/JsonWriter.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonWriter.java
@@ -68,6 +68,13 @@ import java.util.concurrent.atomic.AtomicLong;
  *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *         See the License for the specific language governing permissions and
  *         limitations under the License.
+ * 
+ * 
+ *	2018/09 : Contribution by Jeremie Ratomposon (j.ratompo+jsonio@gmail.com) :
+ * Added a Flat structure serialization mode, to write the output JSON as a flat (single-level nested) associative array.
+ * May be useful for required non-recursive traversing treatments.
+ * 
+ * 
  */
 public class JsonWriter implements Closeable, Flushable
 {
@@ -366,6 +373,15 @@ public class JsonWriter implements Closeable, Flushable
 //    {
 //        this(out, null);
 //    }
+    
+    /**
+     * @see JsonWriter#JsonWriter(OutputStream, Map)
+     * @param out OutputStream to which the JSON will be written.
+     */
+    public JsonWriter()
+    {
+        this(null);
+    }
 
     /**
      * @param out OutputStream to which the JSON output will be written.

--- a/src/main/java/com/cedarsoftware/util/io/JsonWriter.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonWriter.java
@@ -1,16 +1,30 @@
 package com.cedarsoftware.util.io;
 
-import java.io.*;
+import java.io.Closeable;
+import java.io.Flushable;
+import java.io.IOException;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Timestamp;
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import java.util.Set;
+import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -89,6 +103,8 @@ public class JsonWriter implements Closeable, Flushable
     public static final String SKIP_NULL_FIELDS = "SKIP_NULL";
     /** If set, use the specified ClassLoader */
     public static final String CLASSLOADER = "CLASSLOADER";
+    /** If set, writes the JSON in the form of a flat, non-nested structure */
+    public static final String FLAT_STRUCTURE = "FLAT_MAP";
 
     private static Map<Class, JsonClassWriterBase> BASE_WRITERS;
     private final Map<Class, JsonClassWriterBase> writers = new HashMap<Class, JsonClassWriterBase>(BASE_WRITERS);  // Add customer writers (these make common classes more succinct)
@@ -100,7 +116,7 @@ public class JsonWriter implements Closeable, Flushable
     private static final NullClass nullWriter = new NullClass();
     private final Map<Object, Long> objVisited = new IdentityHashMap<Object, Long>();
     private final Map<Object, Long> objsReferenced = new IdentityHashMap<Object, Long>();
-    private final Writer out;
+    private final StringBuilder out;
     private Map<String, String> typeNameMap = null;
     private boolean shortMetaKeys = false;
     private boolean neverShowType = false;
@@ -109,6 +125,7 @@ public class JsonWriter implements Closeable, Flushable
     private boolean isEnumPublicOnly = false;
     private boolean writeLongsAsStrings = false;
     private boolean skipNullFields = false;
+    private boolean isFlatStructure = false;
     private long identity = 1;
     private int depth = 0;
     /** _args is using ThreadLocal so that static inner classes can have access to them */
@@ -160,7 +177,7 @@ public class JsonWriter implements Closeable, Flushable
          * @param output Writer destination to where the actual JSON is written.
          * @throws IOException if thrown by the writer.  Will be caught at a higher level and wrapped in JsonIoException.
          */
-        void write(Object o, boolean showType, Writer output) throws IOException;
+        void write(Object o, boolean showType, final StringBuilder output) throws IOException;
 
         /**
          * @return boolean true if the class being written has a primitive (non-object) form.
@@ -174,7 +191,7 @@ public class JsonWriter implements Closeable, Flushable
          * @param output Writer destination to where the actual JSON is written.
          * @throws IOException if thrown by the writer.  Will be caught at a higher level and wrapped in JsonIoException.
          */
-        void writePrimitiveForm(Object o, Writer output) throws IOException;
+        void writePrimitiveForm(Object o, final StringBuilder output) throws IOException;
     }
 
     /**
@@ -193,7 +210,7 @@ public class JsonWriter implements Closeable, Flushable
          * @param args Map of 'settings' arguments initially passed into the JsonWriter.
          * @throws IOException if thrown by the writer.  Will be caught at a higher level and wrapped in JsonIoException.
          */
-        void write(Object o, boolean showType, Writer output, Map<String, Object> args) throws IOException;
+        void write(Object o, boolean showType, final StringBuilder output, Map<String, Object> args) throws IOException;
 
         /**
          * If access to the JsonWriter is needed, JsonClassWriter's can access it by accessing Support.getWriter(args).
@@ -289,11 +306,13 @@ public class JsonWriter implements Closeable, Flushable
     {
         try
         {
-            ByteArrayOutputStream stream = new ByteArrayOutputStream();
-            JsonWriter writer = new JsonWriter(stream, optionalArgs);
-            writer.write(item);
-            writer.close();
-            return new String(stream.toByteArray(), "UTF-8");
+//          ByteArrayOutputStream stream = new ByteArrayOutputStream();
+//            JsonWriter writer = new JsonWriter(stream, optionalArgs);
+//          writer.write(item);
+//          writer.close();
+//          return new String(stream.toByteArray(), "UTF-8");
+            
+      	  	return new JsonWriter(optionalArgs).write(item);
         }
         catch (Exception e)
         {
@@ -336,14 +355,14 @@ public class JsonWriter implements Closeable, Flushable
         return objectToJson(obj, args);
     }
 
-    /**
-     * @see JsonWriter#JsonWriter(OutputStream, Map)
-     * @param out OutputStream to which the JSON will be written.
-     */
-    public JsonWriter(OutputStream out)
-    {
-        this(out, null);
-    }
+//    /**
+//     * @see JsonWriter#JsonWriter(OutputStream, Map)
+//     * @param out OutputStream to which the JSON will be written.
+//     */
+//    public JsonWriter(OutputStream out)
+//    {
+//        this(out, null);
+//    }
 
     /**
      * @param out OutputStream to which the JSON output will be written.
@@ -355,7 +374,9 @@ public class JsonWriter implements Closeable, Flushable
      * If the DATE_FORMAT key is not used, then dates will be formatted as longs.  This long can
      * be turned back into a date by using 'new Date(longValue)'.
      */
-    public JsonWriter(OutputStream out, Map<String, Object> optionalArgs)
+    public JsonWriter(
+//   		 OutputStream out,
+   		 Map<String, Object> optionalArgs)
     {
         if (optionalArgs == null)
         {
@@ -372,6 +393,8 @@ public class JsonWriter implements Closeable, Flushable
         writeLongsAsStrings = isTrue(args.get(WRITE_LONGS_AS_STRINGS));
         writeLongsAsStrings = isTrue(args.get(WRITE_LONGS_AS_STRINGS));
         skipNullFields = isTrue(args.get(SKIP_NULL_FIELDS));
+        isFlatStructure = isTrue(args.get(FLAT_STRUCTURE));
+        
         if (!args.containsKey(CLASSLOADER))
         {
             args.put(CLASSLOADER, JsonWriter.class.getClassLoader());
@@ -454,14 +477,16 @@ public class JsonWriter implements Closeable, Flushable
             args.put(FIELD_BLACK_LIST, new HashMap());
         }
 
-        try
-        {
-            this.out = new BufferedWriter(new OutputStreamWriter(out, "UTF-8"));
-        }
-        catch (UnsupportedEncodingException e)
-        {
-            throw new JsonIoException("UTF-8 not supported on your JVM.  Unable to convert object to JSON.", e);
-        }
+//       try
+//       {
+//           this.out = new BufferedWriter(new OutputStreamWriter(out, "UTF-8"));
+//       }
+//       catch (UnsupportedEncodingException e)
+//       {
+//           throw new JsonIoException("UTF-8 not supported on your JVM.  Unable to convert object to JSON.", e);
+//       }
+
+		this.out = new StringBuilder();
     }
 
     /**
@@ -498,27 +523,27 @@ public class JsonWriter implements Closeable, Flushable
      * Tab the output left (less indented)
      * @throws IOException
      */
-    public void tabIn() throws IOException
+    public void tabIn(final StringBuilder output) throws IOException
     {
-        tab(out, 1);
+        tab(output, 1);
     }
 
     /**
      * Add newline (\n) to output
      * @throws IOException
      */
-    public void newLine() throws IOException
+    public void newLine(final StringBuilder output) throws IOException
     {
-        tab(out, 0);
+        tab(output, 0);
     }
 
     /**
      * Tab the output right (more indented)
      * @throws IOException
      */
-    public void tabOut() throws IOException
+    public void tabOut(final StringBuilder output) throws IOException
     {
-        tab(out, -1);
+        tab(output, -1);
     }
 
     /**
@@ -527,17 +552,17 @@ public class JsonWriter implements Closeable, Flushable
      * @param delta int number of characters to tab.
      * @throws IOException
      */
-    private void tab(Writer output, int delta) throws IOException
+    private void tab(final StringBuilder output, int delta) throws IOException
     {
         if (!isPrettyPrint)
         {
             return;
         }
-        output.write(NEW_LINE);
+        output.append(NEW_LINE);
         depth += delta;
         for (int i=0; i < depth; i++)
         {
-            output.write("  ");
+            output.append("  ");
         }
     }
 
@@ -549,7 +574,7 @@ public class JsonWriter implements Closeable, Flushable
      * @param output Writer where the actual JSON is being written to.
      * @return boolean true if written, false is there is no custom writer for the passed in object.
      */
-    public boolean writeIfMatching(Object o, boolean showType, Writer output)
+    public boolean writeIfMatching(Object o, boolean showType, final StringBuilder output)
     {
         if (neverShowType)
         {
@@ -580,7 +605,7 @@ public class JsonWriter implements Closeable, Flushable
      * @param output Writer to write the JSON to (if there is a custom writer for o's Class).
      * @return true if the array element was written, false otherwise.
      */
-    public boolean writeArrayElementIfMatching(Class arrayComponentClass, Object o, boolean showType, Writer output)
+    public boolean writeArrayElementIfMatching(Class arrayComponentClass, Object o, boolean showType, final StringBuilder output)
     {
         if (!o.getClass().isAssignableFrom(arrayComponentClass) || notCustom.contains(o.getClass()))
         {
@@ -605,20 +630,20 @@ public class JsonWriter implements Closeable, Flushable
      * @param output Writer to write the JSON to (if there is a custom writer for o's Class).
      * @return true if the array element was written, false otherwise.
      */
-    protected boolean writeCustom(Class arrayComponentClass, Object o, boolean showType, Writer output) throws IOException
+    protected boolean writeCustom(Class arrayComponentClass, Object o, boolean showType, final StringBuilder output) throws IOException
     {
         if (neverShowType)
         {
             showType = false;
         }
-		JsonClassWriterBase closestWriter = getCustomWriter(arrayComponentClass);
+		  JsonClassWriterBase closestWriter = getCustomWriter(arrayComponentClass);
 
         if (closestWriter == null)
         {
             return false;
         }
 
-        if (writeOptionalReference(o))
+        if (writeOptionalReference(o, output))
         {
             return true;
         }
@@ -645,15 +670,15 @@ public class JsonWriter implements Closeable, Flushable
             }
         }
 
-        output.write('{');
-        tabIn();
+        output.append('{');
+        tabIn(output);
         if (referenced)
         {
-            writeId(getId(o));
+            writeId(getId(o), output);
             if (showType)
             {
-                output.write(',');
-                newLine();
+                output.append(',');
+                newLine(output);
             }
         }
 
@@ -664,8 +689,8 @@ public class JsonWriter implements Closeable, Flushable
 
         if (referenced || showType)
         {
-            output.write(',');
-            newLine();
+            output.append(',');
+            newLine(output);
         }
 
         if (closestWriter instanceof JsonClassWriterEx)
@@ -676,8 +701,8 @@ public class JsonWriter implements Closeable, Flushable
         {
             ((JsonClassWriter)closestWriter).write(o, showType || referenced, output);
         }
-        tabOut();
-        output.write('}');
+        tabOut(output);
+        output.append('}');
         return true;
     }
 
@@ -777,13 +802,21 @@ public class JsonWriter implements Closeable, Flushable
      * Write the passed in Java object in JSON format.
      * @param obj Object any Java Object or JsonObject.
      */
-    public void write(Object obj)
+    public String write(Object obj)
     {
+   	 
+   	  final StringBuilder output = this.out;
+   	 
         traceReferences(obj);
         objVisited.clear();
         try
         {
-            writeImpl(obj, true);
+      	  writeImpl(obj, true, output);
+      	  
+      	  if(isFlatStructure){
+      		  // If we want a flat structure, we enclose the map in a JSON object body :
+      		  output.insert(0, '{').append('}');
+      	  }
         }
         catch (Exception e)
         {
@@ -792,6 +825,9 @@ public class JsonWriter implements Closeable, Flushable
         flush();
         objVisited.clear();
         objsReferenced.clear();
+        
+        
+        return output.toString();
     }
 
     /**
@@ -819,6 +855,9 @@ public class JsonWriter implements Closeable, Flushable
 
             if (!MetaUtils.isLogicalPrimitive(obj.getClass()))
             {
+            	
+            	if(!isFlatStructure){ // Default case
+            	
                 Long id = visited.get(obj);
                 if (id != null)
                 {   // Only write an object once.
@@ -835,6 +874,23 @@ public class JsonWriter implements Closeable, Flushable
                     // we don't waste the memory to store a Long instance that is never used.
                     visited.put(obj, ZERO);
                 }
+          		
+            	}else{
+            		
+            		// In the flat structure case, we give an id to al and every non-primitive object :
+                  Long id = visited.get(obj);
+                  if (id != null)
+                  {   // Only write an object once.
+                  	continue;
+                  }else{
+                  	// 1st time this object has been seen, we give it a unique ID and mark it referenced
+                  	id = identity++;
+                  	visited.put(obj, id);
+                  	referenced.put(obj, id);
+                  }
+            		
+            	}
+                
             }
 
             final Class clazz = obj.getClass();
@@ -961,9 +1017,10 @@ public class JsonWriter implements Closeable, Flushable
         return fields;
     }
 
-    private boolean writeOptionalReference(Object obj) throws IOException
+    private boolean writeOptionalReference(Object obj, final StringBuilder output) throws IOException
     {
-        if (obj == null)
+
+   	 if (obj == null)
         {
             return false;
         }
@@ -973,7 +1030,6 @@ public class JsonWriter implements Closeable, Flushable
             return false;
         }
 
-        final Writer output = this.out;
         if (objVisited.containsKey(obj))
         {    // Only write (define) an object once in the JSON stream, otherwise emit a @ref
             String id = getId(obj);
@@ -981,9 +1037,9 @@ public class JsonWriter implements Closeable, Flushable
             {   // Test for null because of Weak/Soft references being gc'd during serialization.
                 return false;
             }
-            output.write(shortMetaKeys ? "{\"@r\":" : "{\"@ref\":");
-            output.write(id);
-            output.write('}');
+            output.append(shortMetaKeys ? "{\"@r\":" : "{\"@ref\":");
+            output.append(id);
+            output.append('}');
             return true;
         }
 
@@ -1003,9 +1059,9 @@ public class JsonWriter implements Closeable, Flushable
      * dropped.
      * @throws IOException if one occurs on the underlying output stream.
      */
-    public void writeImpl(Object obj, boolean showType) throws IOException
+    public void writeImpl(Object obj, boolean showType, final StringBuilder output) throws IOException
     {
-        writeImpl(obj, showType, true, true);
+        writeImpl(obj, showType, true, true, output);
     }
 
     /**
@@ -1023,7 +1079,7 @@ public class JsonWriter implements Closeable, Flushable
      * being passed in.
      * @throws IOException if one occurs on the underlying output stream.
      */
-    public void writeImpl(Object obj, boolean showType, boolean allowRef, boolean allowCustom) throws IOException
+    public void writeImpl(Object obj, boolean showType, boolean allowRef, boolean allowCustom, final StringBuilder output) throws IOException
     {
         if (neverShowType)
         {
@@ -1031,150 +1087,166 @@ public class JsonWriter implements Closeable, Flushable
         }
         if (obj == null)
         {
-            out.write("null");
+            output.append("null");
             return;
         }
 
-        if (allowCustom && writeIfMatching(obj, showType, out))
+        if (allowCustom && writeIfMatching(obj, showType, output))
         {
             return;
         }
 
-        if (allowRef && writeOptionalReference(obj))
+        if (allowRef && writeOptionalReference(obj, output))
         {
             return;
         }
 
         if (obj.getClass().isArray())
         {
-            writeArray(obj, showType);
+            writeArray(obj, showType, output);
         }
         else if (obj instanceof Collection)
         {
-            writeCollection((Collection) obj, showType);
+            writeCollection((Collection) obj, showType, output);
         }
         else if (obj instanceof JsonObject)
         {   // symmetric support for writing Map of Maps representation back as equivalent JSON format.
             JsonObject jObj = (JsonObject) obj;
             if (jObj.isArray())
             {
-                writeJsonObjectArray(jObj, showType);
+                writeJsonObjectArray(jObj, showType, output);
             }
             else if (jObj.isCollection())
             {
-                writeJsonObjectCollection(jObj, showType);
+                writeJsonObjectCollection(jObj, showType, output);
             }
             else if (jObj.isMap())
             {
-                if (!writeJsonObjectMapWithStringKeys(jObj, showType))
+                if (!writeJsonObjectMapWithStringKeys(jObj, showType, output))
                 {
-                    writeJsonObjectMap(jObj, showType);
+                    writeJsonObjectMap(jObj, showType, output);
                 }
             }
             else
             {
-                writeJsonObjectObject(jObj, showType);
+                writeJsonObjectObject(jObj, showType, output);
             }
         }
         else if (obj instanceof Map)
         {
-            if (!writeMapWithStringKeys((Map) obj, showType))
+            if (!writeMapWithStringKeys((Map) obj, showType, output))
             {
-                writeMap((Map) obj, showType);
+                writeMap((Map) obj, showType, output);
             }
         }
         else
         {
-            writeObject(obj, showType, false);
+            StringBuilder sb = getWrittenObject(obj, showType, false);
+            if(!isFlatStructure){
+            	 // Default behavior :
+            	output.append(sb);
+            }else{
+            	// If we want a flat structure :
+            	if(output.length() == 0){
+            		output.insert(0, sb);
+            	}else{
+            		output.insert(0, sb.append(','));
+            		writeOptionalReference(obj, output);
+            	}
+            }
+            
+            
+            
         }
     }
 
-    private void writeId(final String id) throws IOException
+    private void writeId(final String id, final StringBuilder output) throws IOException
     {
-        out.write(shortMetaKeys ? "\"@i\":" : "\"@id\":");
-        out.write(id == null ? "0" : id);
+        output.append(shortMetaKeys ? "\"@i\":" : "\"@id\":");
+        output.append(id == null ? "0" : id);
     }
 
-    private void writeType(Object obj, Writer output) throws IOException
+    private void writeType(Object obj, final StringBuilder output) throws IOException
     {
         if (neverShowType)
         {
             return;
         }
-        output.write(shortMetaKeys ? "\"@t\":\"" : "\"@type\":\"");
+        output.append(shortMetaKeys ? "\"@t\":\"" : "\"@type\":\"");
         final Class c = obj.getClass();
         String typeName = c.getName();
         String shortName = getSubstituteTypeNameIfExists(typeName);
 
         if (shortName != null)
         {
-            output.write(shortName);
-            output.write('"');
+            output.append(shortName);
+            output.append('"');
             return;
         }
 
         String s = c.getName();
         if (s.equals("java.lang.Boolean"))
         {
-            output.write("boolean");
+            output.append("boolean");
         }
         else if (s.equals("java.lang.Byte"))
         {
-            output.write("byte");
+            output.append("byte");
         }
         else if (s.equals("java.lang.Character"))
         {
-            output.write("char");
+            output.append("char");
         }
         else if (s.equals("java.lang.Class"))
         {
-            output.write("class");
+            output.append("class");
         }
         else if (s.equals("java.lang.Double"))
         {
-            output.write("double");
+            output.append("double");
         }
         else if (s.equals("java.lang.Float"))
         {
-            output.write("float");
+            output.append("float");
         }
         else if (s.equals("java.lang.Integer"))
         {
-            output.write("int");
+            output.append("int");
         }
         else if (s.equals("java.lang.Long"))
         {
-            output.write("long");
+            output.append("long");
         }
         else if (s.equals("java.lang.Short"))
         {
-            output.write("short");
+            output.append("short");
         }
         else if (s.equals("java.lang.String"))
         {
-            output.write("string");
+            output.append("string");
         }
         else if (s.equals("java.util.Date"))
         {
-            output.write("date");
+            output.append("date");
         }
         else
         {
-            output.write(c.getName());
+            output.append(c.getName());
         }
 
-        output.write('"');
+        output.append('"');
     }
 
-    private void writePrimitive(final Object obj, boolean showType) throws IOException
+    private void writePrimitive(final Object obj, boolean showType, final StringBuilder output) throws IOException
     {
+
         if (neverShowType)
         {
             showType = false;
         }
         if (obj instanceof Character)
         {
-            writeJsonUtf8String(String.valueOf(obj), out);
+            writeJsonUtf8String(String.valueOf(obj), output);
         }
         else
         {
@@ -1182,37 +1254,39 @@ public class JsonWriter implements Closeable, Flushable
             {
                 if (showType)
                 {
-                    out.write(shortMetaKeys ? "{\"@t\":\"" : "{\"@type\":\"");
-                    out.write(getSubstituteTypeName("long"));
-                    out.write("\",\"value\":\"");
-                    out.write(obj.toString());
-                    out.write("\"}");
+                    output.append(shortMetaKeys ? "{\"@t\":\"" : "{\"@type\":\"");
+                    output.append(getSubstituteTypeName("long"));
+                    output.append("\",\"value\":\"");
+                    output.append(obj.toString());
+                    output.append("\"}");
                 }
                 else
                 {
-                    out.write('"');
-                    out.write(obj.toString());
-                    out.write('"');
+                    output.append('"');
+                    output.append(obj.toString());
+                    output.append('"');
                 }
             }
             else if (obj instanceof Double && (Double.isNaN((Double) obj) || Double.isInfinite((Double) obj)))
             {
-            	out.write("null");
+            	output.append("null");
             }
             else if (obj instanceof Float && (Float.isNaN((Float) obj) || Float.isInfinite((Float) obj)))
             {
-                out.write("null");
+                output.append("null");
             }
             else
             {
-                out.write(obj.toString());
+                output.append(obj.toString());
             }
         }
     }
 
-    private void writeArray(final Object array, boolean showType) throws IOException
+    private void writeArray(final Object array, boolean showType, final StringBuilder output) throws IOException
     {
-        if (neverShowType)
+//   	  final StringBuilder output = this.out; // performance opt: place in final local for quicker access
+        
+   	  if (neverShowType)
         {
             showType = false;
         }
@@ -1222,51 +1296,50 @@ public class JsonWriter implements Closeable, Flushable
 //        boolean typeWritten = showType && !(Object[].class == arrayType);    // causes IDE warning in NetBeans 7/4 Java 1.7
         boolean typeWritten = showType && !(arrayType.equals(Object[].class));
 
-        final Writer output = this.out; // performance opt: place in final local for quicker access
         if (typeWritten || referenced)
         {
-            output.write('{');
-            tabIn();
+            output.append('{');
+            tabIn(output);
         }
 
         if (referenced)
         {
-            writeId(getId(array));
-            output.write(',');
-            newLine();
+            writeId(getId(array), output);
+            output.append(',');
+            newLine(output);
         }
 
         if (typeWritten)
         {
             writeType(array, output);
-            output.write(',');
-            newLine();
+            output.append(',');
+            newLine(output);
         }
 
         if (len == 0)
         {
             if (typeWritten || referenced)
             {
-                output.write(shortMetaKeys ? "\"@e\":[]" : "\"@items\":[]");
-                tabOut();
-                output.write('}');
+                output.append(shortMetaKeys ? "\"@e\":[]" : "\"@items\":[]");
+                tabOut(output);
+                output.append('}');
             }
             else
             {
-                output.write("[]");
+                output.append("[]");
             }
             return;
         }
 
         if (typeWritten || referenced)
         {
-            output.write(shortMetaKeys ? "\"@i\":[" : "\"@items\":[");
+            output.append(shortMetaKeys ? "\"@i\":[" : "\"@items\":[");
         }
         else
         {
-            output.write('[');
+            output.append('[');
         }
-        tabIn();
+        tabIn(output);
 
         final int lenMinus1 = len - 1;
 
@@ -1275,7 +1348,7 @@ public class JsonWriter implements Closeable, Flushable
         // reflective Array.get() but it is slower.  I chose speed over code length.
         if (byte[].class == arrayType)
         {
-            writeByteArray((byte[]) array, lenMinus1);
+            writeByteArray((byte[]) array, lenMinus1, output);
         }
         else if (char[].class == arrayType)
         {
@@ -1283,27 +1356,27 @@ public class JsonWriter implements Closeable, Flushable
         }
         else if (short[].class == arrayType)
         {
-            writeShortArray((short[]) array, lenMinus1);
+            writeShortArray((short[]) array, lenMinus1, output);
         }
         else if (int[].class == arrayType)
         {
-            writeIntArray((int[]) array, lenMinus1);
+            writeIntArray((int[]) array, lenMinus1, output);
         }
         else if (long[].class == arrayType)
         {
-            writeLongArray((long[]) array, lenMinus1);
+            writeLongArray((long[]) array, lenMinus1, output);
         }
         else if (float[].class == arrayType)
         {
-            writeFloatArray((float[]) array, lenMinus1);
+            writeFloatArray((float[]) array, lenMinus1, output);
         }
         else if (double[].class == arrayType)
         {
-            writeDoubleArray((double[]) array, lenMinus1);
+            writeDoubleArray((double[]) array, lenMinus1, output);
         }
         else if (boolean[].class == arrayType)
         {
-            writeBooleanArray((boolean[]) array, lenMinus1);
+            writeBooleanArray((boolean[]) array, lenMinus1, output);
         }
         else
         {
@@ -1316,71 +1389,68 @@ public class JsonWriter implements Closeable, Flushable
 
                 if (value == null)
                 {
-                    output.write("null");
+                    output.append("null");
                 }
                 else if (writeArrayElementIfMatching(componentClass, value, false, output)) { }
                 else if (isPrimitiveArray || value instanceof Boolean || value instanceof Long || value instanceof Double)
                 {
-                    writePrimitive(value, value.getClass() != componentClass);
+                    writePrimitive(value, value.getClass() != componentClass, output);
                 }
                 else if (neverShowType && MetaUtils.isPrimitive(value.getClass()))
                 {   // When neverShowType specified, do not allow primitives to show up as {"value":6} for example.
-                    writePrimitive(value, false);
+                    writePrimitive(value, false, output);
                 }
                 else
                 {   // Specific Class-type arrays - only force type when
                     // the instance is derived from array base class.
                     boolean forceType = !(value.getClass() == componentClass);
-                    writeImpl(value, forceType || alwaysShowType);
+                    writeImpl(value, forceType || alwaysShowType, output);
                 }
 
                 if (i != lenMinus1)
                 {
-                    output.write(',');
-                    newLine();
+                    output.append(',');
+                    newLine(output);
                 }
             }
         }
 
-        tabOut();
-        output.write(']');
+        tabOut(output);
+        output.append(']');
         if (typeWritten || referenced)
         {
-            tabOut();
-            output.write('}');
+            tabOut(output);
+            output.append('}');
         }
     }
 
-    private void writeBooleanArray(boolean[] booleans, int lenMinus1) throws IOException
+    private void writeBooleanArray(boolean[] booleans, int lenMinus1, final StringBuilder output) throws IOException
     {
-        final Writer output = this.out;
         for (int i = 0; i < lenMinus1; i++)
         {
-            output.write(booleans[i] ? "true," : "false,");
+            output.append(booleans[i] ? "true," : "false,");
         }
-        output.write(Boolean.toString(booleans[lenMinus1]));
+        output.append(Boolean.toString(booleans[lenMinus1]));
     }
 
-    private void writeDoubleArray(double[] doubles, int lenMinus1) throws IOException
+    private void writeDoubleArray(double[] doubles, int lenMinus1, final StringBuilder output) throws IOException
     {
-        final Writer output = this.out;
         for (int i = 0; i < lenMinus1; i++)
         {
-            output.write(doubleToString(doubles[i]));
-            output.write(',');
+            output.append(doubleToString(doubles[i]));
+            output.append(',');
         }
-        output.write(doubleToString(doubles[lenMinus1]));
+        output.append(doubleToString(doubles[lenMinus1]));
     }
 
-    private void writeFloatArray(float[] floats, int lenMinus1) throws IOException
+    private void writeFloatArray(float[] floats, int lenMinus1, final StringBuilder output) throws IOException
     {
-        final Writer output = this.out;
         for (int i = 0; i < lenMinus1; i++)
         {
-            output.write(floatToString(floats[i]));
-            output.write(',');
+            output.append(floatToString(floats[i]));
+            output.append(',');
         }
-        output.write(floatToString(floats[lenMinus1]));
+        output.append(floatToString(floats[lenMinus1]));
     }
 
     private String doubleToString(double d)
@@ -1393,132 +1463,127 @@ public class JsonWriter implements Closeable, Flushable
     	return (Float.isNaN(d) || Float.isInfinite(d)) ? "null" : Float.toString(d);
     }
 
-    private void writeLongArray(long[] longs, int lenMinus1) throws IOException
+    private void writeLongArray(long[] longs, int lenMinus1, final StringBuilder output) throws IOException
     {
-        final Writer output = this.out;
         if (writeLongsAsStrings)
         {
             for (int i = 0; i < lenMinus1; i++)
             {
-                output.write('"');
-                output.write(Long.toString(longs[i]));
-                output.write('"');
-                output.write(',');
+                output.append('"');
+                output.append(Long.toString(longs[i]));
+                output.append('"');
+                output.append(',');
             }
-            output.write('"');
-            output.write(Long.toString(longs[lenMinus1]));
-            output.write('"');
+            output.append('"');
+            output.append(Long.toString(longs[lenMinus1]));
+            output.append('"');
         }
         else
         {
             for (int i = 0; i < lenMinus1; i++)
             {
-                output.write(Long.toString(longs[i]));
-                output.write(',');
+                output.append(Long.toString(longs[i]));
+                output.append(',');
             }
-            output.write(Long.toString(longs[lenMinus1]));
+            output.append(Long.toString(longs[lenMinus1]));
         }
     }
 
-    private void writeIntArray(int[] ints, int lenMinus1) throws IOException
+    private void writeIntArray(int[] ints, int lenMinus1, final StringBuilder output) throws IOException
     {
-        final Writer output = this.out;
         for (int i = 0; i < lenMinus1; i++)
         {
-            output.write(Integer.toString(ints[i]));
-            output.write(',');
+            output.append(Integer.toString(ints[i]));
+            output.append(',');
         }
-        output.write(Integer.toString(ints[lenMinus1]));
+        output.append(Integer.toString(ints[lenMinus1]));
     }
 
-    private void writeShortArray(short[] shorts, int lenMinus1) throws IOException
+    private void writeShortArray(short[] shorts, int lenMinus1, final StringBuilder output) throws IOException
     {
-        final Writer output = this.out;
         for (int i = 0; i < lenMinus1; i++)
         {
-            output.write(Integer.toString(shorts[i]));
-            output.write(',');
+            output.append(Integer.toString(shorts[i]));
+            output.append(',');
         }
-        output.write(Integer.toString(shorts[lenMinus1]));
+        output.append(Integer.toString(shorts[lenMinus1]));
     }
 
-    private void writeByteArray(byte[] bytes, int lenMinus1) throws IOException
+    private void writeByteArray(byte[] bytes, int lenMinus1, final StringBuilder output) throws IOException
     {
-        final Writer output = this.out;
         final Object[] byteStrs = byteStrings;
         for (int i = 0; i < lenMinus1; i++)
         {
-            output.write((char[]) byteStrs[bytes[i] + 128]);
-            output.write(',');
+            output.append((char[]) byteStrs[bytes[i] + 128]);
+            output.append(',');
         }
-        output.write((char[]) byteStrs[bytes[lenMinus1] + 128]);
+        output.append((char[]) byteStrs[bytes[lenMinus1] + 128]);
     }
 
-    private void writeCollection(Collection col, boolean showType) throws IOException
+    private void writeCollection(Collection col, boolean showType, final StringBuilder output) throws IOException
     {
-        if (neverShowType)
+   	  if (neverShowType)
         {
             showType = false;
         }
-        final Writer output = this.out;
         boolean referenced = objsReferenced.containsKey(col);
         boolean isEmpty = col.isEmpty();
 
         if (referenced || showType)
         {
-            output.write('{');
-            tabIn();
+            output.append('{');
+            tabIn(output);
         }
         else if (isEmpty)
         {
-            output.write('[');
+            output.append('[');
         }
 
-        writeIdAndTypeIfNeeded(col, showType, referenced);
+        writeIdAndTypeIfNeeded(col, showType, referenced, output);
 
         if (isEmpty)
         {
             if (referenced || showType)
             {
-                tabOut();
-                output.write('}');
+                tabOut(output);
+                output.append('}');
             }
             else
             {
-                output.write(']');
+                output.append(']');
             }
             return;
         }
 
-        beginCollection(showType, referenced);
+        beginCollection(showType, referenced, output);
         Iterator i = col.iterator();
 
         writeElements(output, i);
 
-        tabOut();
-        output.write(']');
+        tabOut(output);
+        output.append(']');
         if (showType || referenced)
         {   // Finished object, as it was output as an object if @id or @type was output
-            tabOut();
-            output.write("}");
+            tabOut(output);
+            output.append("}");
         }
     }
 
-    private void writeElements(Writer output, Iterator i) throws IOException
+    private void writeElements(final StringBuilder output, Iterator i) throws IOException
     {
         while (i.hasNext())
         {
-            writeCollectionElement(i.next());
+            writeCollectionElement(i.next(), output);
 
             if (i.hasNext())
             {
-                output.write(',');
-                newLine();
+                output.append(',');
+                newLine(output);
             }
         }
     }
 
-    private void writeIdAndTypeIfNeeded(Object col, boolean showType, boolean referenced) throws IOException
+    private void writeIdAndTypeIfNeeded(Object col, boolean showType, boolean referenced, final StringBuilder output) throws IOException
     {
         if (neverShowType)
         {
@@ -1526,36 +1591,36 @@ public class JsonWriter implements Closeable, Flushable
         }
         if (referenced)
         {
-            writeId(getId(col));
+            writeId(getId(col), output);
         }
 
         if (showType)
         {
             if (referenced)
             {
-                out.write(',');
-                newLine();
+            	output.append(',');
+                newLine(output);
             }
-            writeType(col, out);
+            writeType(col, output);
         }
     }
 
-    private void beginCollection(boolean showType, boolean referenced) throws IOException
+    private void beginCollection(boolean showType, boolean referenced, final StringBuilder output) throws IOException
     {
         if (showType || referenced)
         {
-            out.write(',');
-            newLine();
-            out.write(shortMetaKeys ? "\"@e\":[" : "\"@items\":[");
+      	  output.append(',');
+           newLine(output);
+           output.append(shortMetaKeys ? "\"@e\":[" : "\"@items\":[");
         }
         else
         {
-            out.write('[');
+      	  output.append('[');
         }
-        tabIn();
+        tabIn(output);
     }
 
-    private void writeJsonObjectArray(JsonObject jObj, boolean showType) throws IOException
+    private void writeJsonObjectArray(JsonObject jObj, boolean showType, final StringBuilder output) throws IOException
     {
         if (neverShowType)
         {
@@ -1574,7 +1639,6 @@ public class JsonWriter implements Closeable, Flushable
             arrayClass = MetaUtils.classForName(type, getClassLoader());
         }
 
-        final Writer output = this.out;
         final boolean isObjectArray = Object[].class == arrayClass;
         final Class componentClass = arrayClass.getComponentType();
         boolean referenced = objsReferenced.containsKey(jObj) && jObj.hasId();
@@ -1582,49 +1646,49 @@ public class JsonWriter implements Closeable, Flushable
 
         if (typeWritten || referenced)
         {
-            output.write('{');
-            tabIn();
+            output.append('{');
+            tabIn(output);
         }
 
         if (referenced)
         {
-            writeId(Long.toString(jObj.id));
-            output.write(',');
-            newLine();
+            writeId(Long.toString(jObj.id), output);
+            output.append(',');
+            newLine(output);
         }
 
         if (typeWritten)
         {
-            output.write(shortMetaKeys ? "\"@t\":\"" : "\"@type\":\"");
-            output.write(getSubstituteTypeName(arrayClass.getName()));
-            output.write("\",");
-            newLine();
+            output.append(shortMetaKeys ? "\"@t\":\"" : "\"@type\":\"");
+            output.append(getSubstituteTypeName(arrayClass.getName()));
+            output.append("\",");
+            newLine(output);
         }
 
         if (len == 0)
         {
             if (typeWritten || referenced)
             {
-                output.write(shortMetaKeys ? "\"@e\":[]" : "\"@items\":[]");
-                tabOut();
-                output.write("}");
+                output.append(shortMetaKeys ? "\"@e\":[]" : "\"@items\":[]");
+                tabOut(output);
+                output.append("}");
             }
             else
             {
-                output.write("[]");
+                output.append("[]");
             }
             return;
         }
 
         if (typeWritten || referenced)
         {
-            output.write(shortMetaKeys ? "\"@e\":[" : "\"@items\":[");
+            output.append(shortMetaKeys ? "\"@e\":[" : "\"@items\":[");
         }
         else
         {
-            output.write('[');
+            output.append('[');
         }
-        tabIn();
+        tabIn(output);
 
         Object[] items = (Object[]) jObj.get("@items");
         final int lenMinus1 = len - 1;
@@ -1635,7 +1699,7 @@ public class JsonWriter implements Closeable, Flushable
 
             if (value == null)
             {
-                output.write("null");
+                output.append("null");
             }
             else if (Character.class == componentClass || char.class == componentClass)
             {
@@ -1643,11 +1707,11 @@ public class JsonWriter implements Closeable, Flushable
             }
             else if (value instanceof Boolean || value instanceof Long || value instanceof Double)
             {
-                writePrimitive(value, value.getClass() != componentClass);
+                writePrimitive(value, value.getClass() != componentClass, output);
             }
             else if (neverShowType && MetaUtils.isPrimitive(value.getClass()))
             {
-                writePrimitive(value, false);
+                writePrimitive(value, false, output);
             }
             else if (value instanceof String)
             {   // Have to specially treat String because it could be referenced, but we still want inline (no @type, value:)
@@ -1658,26 +1722,26 @@ public class JsonWriter implements Closeable, Flushable
             {   // Specific Class-type arrays - only force type when
                 // the instance is derived from array base class.
                 boolean forceType = !(value.getClass() == componentClass);
-                writeImpl(value, forceType || alwaysShowType);
+                writeImpl(value, forceType || alwaysShowType, output);
             }
 
             if (i != lenMinus1)
             {
-                output.write(',');
-                newLine();
+                output.append(',');
+                newLine(output);
             }
         }
 
-        tabOut();
-        output.write(']');
+        tabOut(output);
+        output.append(']');
         if (typeWritten || referenced)
         {
-            tabOut();
-            output.write('}');
+            tabOut(output);
+            output.append('}');
         }
     }
 
-    private void writeJsonObjectCollection(JsonObject jObj, boolean showType) throws IOException
+    private void writeJsonObjectCollection(JsonObject jObj, boolean showType, final StringBuilder output) throws IOException
     {
         if (neverShowType)
         {
@@ -1686,40 +1750,39 @@ public class JsonWriter implements Closeable, Flushable
         String type = jObj.type;
         Class colClass = MetaUtils.classForName(type, getClassLoader());
         boolean referenced = objsReferenced.containsKey(jObj) && jObj.hasId();
-        final Writer output = this.out;
         int len = jObj.getLength();
 
         if (referenced || showType || len == 0)
         {
-            output.write('{');
-            tabIn();
+            output.append('{');
+            tabIn(output);
         }
 
         if (referenced)
         {
-            writeId(String.valueOf(jObj.id));
+            writeId(String.valueOf(jObj.id), output);
         }
 
         if (showType)
         {
             if (referenced)
             {
-                output.write(',');
-                newLine();
+                output.append(',');
+                newLine(output);
             }
-            output.write(shortMetaKeys ? "\"@t\":\"" : "\"@type\":\"");
-            output.write(getSubstituteTypeName(colClass.getName()));
-            output.write('"');
+            output.append(shortMetaKeys ? "\"@t\":\"" : "\"@type\":\"");
+            output.append(getSubstituteTypeName(colClass.getName()));
+            output.append('"');
         }
 
         if (len == 0)
         {
-            tabOut();
-            output.write('}');
+            tabOut(output);
+            output.append('}');
             return;
         }
 
-        beginCollection(showType, referenced);
+        beginCollection(showType, referenced, output);
 
         Object[] items = (Object[]) jObj.get("@items");
         final int itemsLen = items.length;
@@ -1727,54 +1790,53 @@ public class JsonWriter implements Closeable, Flushable
 
         for (int i=0; i < itemsLen; i++)
         {
-            writeCollectionElement(items[i]);
+            writeCollectionElement(items[i], output);
 
             if (i != itemsLenMinus1)
             {
-                output.write(',');
-                newLine();
+                output.append(',');
+                newLine(output);
             }
         }
 
-        tabOut();
-        output.write("]");
+        tabOut(output);
+        output.append("]");
         if (showType || referenced)
         {
-            tabOut();
-            output.write('}');
+            tabOut(output);
+            output.append('}');
         }
     }
 
-    private void writeJsonObjectMap(JsonObject jObj, boolean showType) throws IOException
+    private void writeJsonObjectMap(JsonObject jObj, boolean showType, final StringBuilder output) throws IOException
     {
         if (neverShowType)
         {
             showType = false;
         }
         boolean referenced = objsReferenced.containsKey(jObj) && jObj.hasId();
-        final Writer output = this.out;
 
-        output.write('{');
-        tabIn();
+        output.append('{');
+        tabIn(output);
         if (referenced)
         {
-            writeId(String.valueOf(jObj.getId()));
+            writeId(String.valueOf(jObj.getId()), output);
         }
 
         if (showType)
         {
             if (referenced)
             {
-                output.write(',');
-                newLine();
+                output.append(',');
+                newLine(output);
             }
             String type = jObj.getType();
             if (type != null)
             {
                 Class mapClass = MetaUtils.classForName(type, getClassLoader());
-                output.write(shortMetaKeys ? "\"@t\":\"" : "\"@type\":\"");
-                output.write(getSubstituteTypeName(mapClass.getName()));
-                output.write('"');
+                output.append(shortMetaKeys ? "\"@t\":\"" : "\"@type\":\"");
+                output.append(getSubstituteTypeName(mapClass.getName()));
+                output.append('"');
             }
             else
             {   // type not displayed
@@ -1784,40 +1846,40 @@ public class JsonWriter implements Closeable, Flushable
 
         if (jObj.isEmpty())
         {   // Empty
-            tabOut();
-            output.write('}');
+            tabOut(output);
+            output.append('}');
             return;
         }
 
         if (showType)
         {
-            output.write(',');
-            newLine();
+            output.append(',');
+            newLine(output);
         }
 
-        output.write(shortMetaKeys ? "\"@k\":[" : "\"@keys\":[");
-        tabIn();
+        output.append(shortMetaKeys ? "\"@k\":[" : "\"@keys\":[");
+        tabIn(output);
         Iterator i = jObj.keySet().iterator();
 
         writeElements(output, i);
 
-        tabOut();
-        output.write("],");
-        newLine();
-        output.write(shortMetaKeys ? "\"@e\":[" : "\"@items\":[");
-        tabIn();
+        tabOut(output);
+        output.append("],");
+        newLine(output);
+        output.append(shortMetaKeys ? "\"@e\":[" : "\"@items\":[");
+        tabIn(output);
         i =jObj.values().iterator();
 
         writeElements(output, i);
 
-        tabOut();
-        output.write(']');
-        tabOut();
-        output.write('}');
+        tabOut(output);
+        output.append(']');
+        tabOut(output);
+        output.append('}');
     }
 
 
-    private boolean writeJsonObjectMapWithStringKeys(JsonObject jObj, boolean showType) throws IOException
+    private boolean writeJsonObjectMapWithStringKeys(JsonObject jObj, boolean showType, final StringBuilder output) throws IOException
     {
         if (neverShowType)
         {
@@ -1830,29 +1892,28 @@ public class JsonWriter implements Closeable, Flushable
         }
 
         boolean referenced = objsReferenced.containsKey(jObj) && jObj.hasId();
-        final Writer output = this.out;
-        output.write('{');
-        tabIn();
+        output.append('{');
+        tabIn(output);
 
         if (referenced)
         {
-            writeId(String.valueOf(jObj.getId()));
+            writeId(String.valueOf(jObj.getId()), output);
         }
 
         if (showType)
         {
             if(referenced)
             {
-                output.write(',');
-                newLine();
+                output.append(',');
+                newLine(output);
             }
             String type = jObj.getType();
             if (type != null)
             {
                 Class mapClass = MetaUtils.classForName(type, getClassLoader());
-                output.write(shortMetaKeys ? "\"@t\":\"" : "\"@type\":\"");
-                output.write(getSubstituteTypeName(mapClass.getName()));
-                output.write('"');
+                output.append(shortMetaKeys ? "\"@t\":\"" : "\"@type\":\"");
+                output.append(getSubstituteTypeName(mapClass.getName()));
+                output.append('"');
             }
             else
             { // type not displayed
@@ -1862,65 +1923,64 @@ public class JsonWriter implements Closeable, Flushable
 
         if (jObj.isEmpty())
         { // Empty
-            tabOut();
-            output.write('}');
+            tabOut(output);
+            output.append('}');
             return true;
         }
 
         if (showType)
         {
-            output.write(',');
-            newLine();
+            output.append(',');
+            newLine(output);
         }
 
-        return writeMapBody(jObj.entrySet().iterator());
+        return writeMapBody(jObj.entrySet().iterator(), output);
     }
 
     /**
      * Write fields of an Object (JsonObject)
      */
-    private void writeJsonObjectObject(JsonObject jObj, boolean showType) throws IOException
+    private void writeJsonObjectObject(JsonObject jObj, boolean showType, final StringBuilder output) throws IOException
     {
         if (neverShowType)
         {
             showType = false;
         }
-        final Writer output = this.out;
         boolean referenced = objsReferenced.containsKey(jObj) && jObj.hasId();
         showType = showType && jObj.type != null;
         Class type = null;
 
-        output.write('{');
-        tabIn();
+        output.append('{');
+        tabIn(output);
         if (referenced)
         {
-            writeId(String.valueOf(jObj.id));
+            writeId(String.valueOf(jObj.id), output);
         }
 
         if (showType)
         {
             if (referenced)
             {
-                output.write(',');
-                newLine();
+                output.append(',');
+                newLine(output);
             }
-            output.write(shortMetaKeys ? "\"@t\":\"" : "\"@type\":\"");
-            output.write(getSubstituteTypeName(jObj.type));
-            output.write('"');
+            output.append(shortMetaKeys ? "\"@t\":\"" : "\"@type\":\"");
+            output.append(getSubstituteTypeName(jObj.type));
+            output.append('"');
             try  { type = MetaUtils.classForName(jObj.type, getClassLoader()); } catch(Exception ignored) { type = null; }
         }
 
         if (jObj.isEmpty())
         {
-            tabOut();
-            output.write('}');
+            tabOut(output);
+            output.append('}');
             return;
         }
 
         if (showType || referenced)
         {
-            output.write(',');
-            newLine();
+            output.append(',');
+            newLine(output);
         }
 
         Iterator<Map.Entry<String,Object>> i = jObj.entrySet().iterator();
@@ -1936,31 +1996,31 @@ public class JsonWriter implements Closeable, Flushable
 
             if (!first)
             {
-                output.write(',');
-                newLine();
+                output.append(',');
+                newLine(output);
             }
             first = false;
             final String fieldName = entry.getKey();
-            output.write('"');
-            output.write(fieldName);
-            output.write("\":");
+            output.append('"');
+            output.append(fieldName);
+            output.append("\":");
             Object value = entry.getValue();
 
             if (value == null)
             {
-                output.write("null");
+                output.append("null");
             }
             else if (neverShowType && MetaUtils.isPrimitive(value.getClass()))
             {
-                writePrimitive(value, false);
+                writePrimitive(value, false, output);
             }
             else if (value instanceof BigDecimal || value instanceof BigInteger)
             {
-                writeImpl(value, !doesValueTypeMatchFieldType(type, fieldName, value));
+                writeImpl(value, !doesValueTypeMatchFieldType(type, fieldName, value), output);
             }
             else if (value instanceof Number || value instanceof Boolean)
             {
-                output.write(value.toString());
+                output.append(value.toString());
             }
             else if (value instanceof String)
             {
@@ -1972,11 +2032,11 @@ public class JsonWriter implements Closeable, Flushable
             }
             else
             {
-                writeImpl(value, !doesValueTypeMatchFieldType(type, fieldName, value));
+                writeImpl(value, !doesValueTypeMatchFieldType(type, fieldName, value), output);
             }
         }
-        tabOut();
-        output.write('}');
+        tabOut(output);
+        output.append('}');
     }
 
     private static boolean doesValueTypeMatchFieldType(Class type, String fieldName, Object value)
@@ -1990,68 +2050,67 @@ public class JsonWriter implements Closeable, Flushable
         return false;
     }
 
-    private void writeMap(Map map, boolean showType) throws IOException
+    private void writeMap(Map map, boolean showType, final StringBuilder output) throws IOException
     {
         if (neverShowType)
         {
             showType = false;
         }
-        final Writer output = this.out;
         boolean referenced = objsReferenced.containsKey(map);
 
-        output.write('{');
-        tabIn();
+        output.append('{');
+        tabIn(output);
         if (referenced)
         {
-            writeId(getId(map));
+            writeId(getId(map), output);
         }
 
         if (showType)
         {
             if (referenced)
             {
-                output.write(',');
-                newLine();
+                output.append(',');
+                newLine(output);
             }
             writeType(map, output);
         }
 
         if (map.isEmpty())
         {
-            tabOut();
-            output.write('}');
+            tabOut(output);
+            output.append('}');
             return;
         }
 
         if (showType || referenced)
         {
-            output.write(',');
-            newLine();
+            output.append(',');
+            newLine(output);
         }
 
-        output.write(shortMetaKeys ? "\"@k\":[" : "\"@keys\":[");
-        tabIn();
+        output.append(shortMetaKeys ? "\"@k\":[" : "\"@keys\":[");
+        tabIn(output);
         Iterator i = map.keySet().iterator();
 
         writeElements(output, i);
 
-        tabOut();
-        output.write("],");
-        newLine();
-        output.write(shortMetaKeys ? "\"@e\":[" : "\"@items\":[");
-        tabIn();
+        tabOut(output);
+        output.append("],");
+        newLine(output);
+        output.append(shortMetaKeys ? "\"@e\":[" : "\"@items\":[");
+        tabIn(output);
         i = map.values().iterator();
 
         writeElements(output, i);
 
-        tabOut();
-        output.write(']');
-        tabOut();
-        output.write('}');
+        tabOut(output);
+        output.append(']');
+        tabOut(output);
+        output.append('}');
     }
 
 
-    private boolean writeMapWithStringKeys(Map map, boolean showType) throws IOException
+    private boolean writeMapWithStringKeys(Map map, boolean showType, final StringBuilder output) throws IOException
     {
         if (neverShowType)
         {
@@ -2064,46 +2123,45 @@ public class JsonWriter implements Closeable, Flushable
 
         boolean referenced = objsReferenced.containsKey(map);
 
-        out.write('{');
-        tabIn();
-        writeIdAndTypeIfNeeded(map, showType, referenced);
+        output.append('{');
+        tabIn(output);
+        writeIdAndTypeIfNeeded(map, showType, referenced, output);
 
         if (map.isEmpty())
         {
-            tabOut();
-            out.write('}');
+            tabOut(output);
+            output.append('}');
             return true;
         }
 
         if (showType || referenced)
         {
-            out.write(',');
-            newLine();
+            output.append(',');
+            newLine(output);
         }
 
-        return writeMapBody(map.entrySet().iterator());
+       return writeMapBody(map.entrySet().iterator(), output);
     }
 
-    private boolean writeMapBody(final Iterator i) throws IOException
+    private boolean writeMapBody(final Iterator i, final StringBuilder output) throws IOException
     {
-        final Writer output = out;
         while (i.hasNext())
         {
             Entry att2value = (Entry) i.next();
             writeJsonUtf8String((String)att2value.getKey(), output);
-            output.write(":");
+            output.append(":");
 
-            writeCollectionElement(att2value.getValue());
+            writeCollectionElement(att2value.getValue(), output);
 
             if (i.hasNext())
             {
-                output.write(',');
-                newLine();
+                output.append(',');
+                newLine(output);
             }
         }
 
-        tabOut();
-        output.write('}');
+        tabOut(output);
+        output.append('}');
         return true;
     }
 
@@ -2132,32 +2190,32 @@ public class JsonWriter implements Closeable, Flushable
      * @param o Collection element to output in JSON format.
      * @throws IOException if an error occurs writing to the output stream.
      */
-    private void writeCollectionElement(Object o) throws IOException
+    private void writeCollectionElement(Object o, final StringBuilder output) throws IOException
     {
         if (o == null)
         {
-            out.write("null");
+            output.append("null");
         }
         else if (o instanceof Boolean || o instanceof Double)
         {
-            writePrimitive(o, false);
+            writePrimitive(o, false, output);
         }
         else if (o instanceof Long)
         {
-            writePrimitive(o, writeLongsAsStrings);
+            writePrimitive(o, writeLongsAsStrings, output);
         }
         else if (o instanceof String)
         {   // Never do an @ref to a String (they are treated as logical primitives and intern'ed on read)
-            writeJsonUtf8String((String) o, out);
+            writeJsonUtf8String((String) o, output);
         }
         else if (neverShowType && MetaUtils.isPrimitive(o.getClass()))
         {   // If neverShowType, then force primitives (and primitive wrappers)
             // to be output with toString() - prevents {"value":6} for example
-            writePrimitive(o, false);
+            writePrimitive(o, false, output);
         }
         else
         {
-            writeImpl(o, true);
+            writeImpl(o, true, output);
         }
     }
 
@@ -2169,8 +2227,11 @@ public class JsonWriter implements Closeable, Flushable
      * @param bodyOnly write only the body of the object
      * @throws IOException if an error occurs writing to the output stream.
      */
-    public void writeObject(final Object obj, boolean showType, boolean bodyOnly) throws IOException
+    public StringBuilder getWrittenObject(final Object obj, boolean showType, boolean bodyOnly) throws IOException
     {
+   	  final StringBuilder output = new StringBuilder();
+//   	  final StringBuilder output = this.out;
+
         if (neverShowType)
         {
             showType = false;
@@ -2178,22 +2239,30 @@ public class JsonWriter implements Closeable, Flushable
         final boolean referenced = objsReferenced.containsKey(obj);
         if (!bodyOnly)
         {
-            out.write('{');
-            tabIn();
+      	
+      	  	if(isFlatStructure){
+      	  		// If we want a flat structure JSON output :
+		        	Long idObj = this.objsReferenced.get(obj);
+		        	String idStr = String.format("\"%d\":", idObj);
+		        	output.insert(0, idStr);
+      	  	}
+      	  
+            output.append('{');
+            tabIn(output);
             if (referenced)
             {
-                writeId(getId(obj));
+                writeId(getId(obj), output);
             }
 
             if (referenced && showType)
             {
-                out.write(',');
-                newLine();
+                output.append(',');
+                newLine(output);
             }
 
             if (showType)
             {
-                writeType(obj, out);
+                writeType(obj, output);
             }
         }
 
@@ -2212,7 +2281,7 @@ public class JsonWriter implements Closeable, Flushable
             {   //output field if not on the blacklist
                 if (fieldBlackListForClass == null || !fieldBlackListForClass.contains(field)){
                     // Not currently supporting overwritten field names in hierarchy when using external field specifier
-                    first = writeField(obj, first, field.getName(), field, true);
+                    first = writeField(obj, first, field.getName(), field, true, output);
                 }//else field is black listed.
             }
         }
@@ -2225,20 +2294,24 @@ public class JsonWriter implements Closeable, Flushable
                 final Field field = entry.getValue();
                 //output field if not on the blacklist
                 if (fieldBlackListForClass == null || !fieldBlackListForClass.contains(field)){
-                    first = writeField(obj, first, fieldName, field, false);
+                    first = writeField(obj, first, fieldName, field, false, output);
                 }//else field is black listed.
             }
         }
 
         if (!bodyOnly)
         {
-            tabOut();
-            out.write('}');
+            tabOut(output);
+            output.append('}');
         }
+        
+        
+        return output;
     }
 
-    private boolean writeField(Object obj, boolean first, String fieldName, Field field, boolean allowTransient) throws IOException
+    private boolean writeField(Object obj, boolean first, String fieldName, Field field, boolean allowTransient, final StringBuilder output) throws IOException
     {
+   	 
         if (!allowTransient && (field.getModifiers() & Modifier.TRANSIENT) != 0)
         {   // Do not write transient fields
             return first;
@@ -2277,17 +2350,17 @@ public class JsonWriter implements Closeable, Flushable
 
         if (!first)
         {
-            out.write(',');
-            newLine();
+            output.append(',');
+            newLine(output);
         }
 
-        writeJsonUtf8String(fieldName, out);
-        out.write(':');
+        writeJsonUtf8String(fieldName, output);
+        output.append(':');
 
 
         if (o == null)
         {    // don't quote null
-            out.write("null");
+            output.append("null");
             return false;
         }
 
@@ -2297,11 +2370,11 @@ public class JsonWriter implements Closeable, Flushable
         //When no type is written we can check the Object itself not the declaration
         if (MetaUtils.isPrimitive(type) || (neverShowType && MetaUtils.isPrimitive(o.getClass())))
         {
-            writePrimitive(o, false);
+            writePrimitive(o, false, output);
         }
         else
         {
-            writeImpl(o, forceType || alwaysShowType, true, true);
+            writeImpl(o, forceType || alwaysShowType, true, true, output);
         }
         return false;
     }
@@ -2315,9 +2388,9 @@ public class JsonWriter implements Closeable, Flushable
      * @param output Writer to which the UTF-8 string will be written to
      * @throws IOException if an error occurs writing to the output stream.
      */
-    public static void writeJsonUtf8String(String s, final Writer output) throws IOException
+    public static void writeJsonUtf8String(String s, final StringBuilder output) throws IOException
     {
-        output.write('\"');
+        output.append('\"');
         final int len = s.length();
 
         for (int i = 0; i < len; i++)
@@ -2329,57 +2402,59 @@ public class JsonWriter implements Closeable, Flushable
                 switch (c)
                 {
                     case '\b':
-                        output.write("\\b");
+                        output.append("\\b");
                         break;
                     case '\f':
-                        output.write("\\f");
+                        output.append("\\f");
                         break;
                     case '\n':
-                        output.write("\\n");
+                        output.append("\\n");
                         break;
                     case '\r':
-                        output.write("\\r");
+                        output.append("\\r");
                         break;
                     case '\t':
-                        output.write("\\t");
+                        output.append("\\t");
                         break;
                     default:
-                        output.write(String.format("\\u%04X", (int)c));
+                        output.append(String.format("\\u%04X", (int)c));
                         break;
                 }
             }
             else if (c == '\\' || c == '"')
             {
-                output.write('\\');
-                output.write(c);
+                output.append('\\');
+                output.append(c);
             }
             else
             {   // Anything else - write in UTF-8 form (multi-byte encoded) (OutputStreamWriter is UTF-8)
-                output.write(c);
+                output.append(c);
             }
         }
-        output.write('\"');
+        output.append('\"');
     }
 
+    @Override
     public void flush()
     {
-        try
-        {
-            if (out != null)
-            {
-                out.flush();
-            }
-        }
-        catch (Exception ignored) { }
+//        try
+//        {
+//            if (out != null)
+//            {
+//                out.flush();
+//            }
+//        }
+//        catch (Exception ignored) { }
     }
 
-    public void close()
+    @Override
+	public void close()
     {
-        try
-        {
-            out.close();
-        }
-        catch (Exception ignore) { }
+//        try
+//        {
+//            out.close();
+//        }
+//        catch (Exception ignore) { }
         writerCache.clear();
         writers.clear();
     }

--- a/src/main/java/com/cedarsoftware/util/io/Writers.java
+++ b/src/main/java/com/cedarsoftware/util/io/Writers.java
@@ -1,7 +1,6 @@
 package com.cedarsoftware.util.io;
 
 import java.io.IOException;
-import java.io.Writer;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Timestamp;
@@ -43,43 +42,51 @@ public class Writers
     
     public static class TimeZoneWriter implements JsonWriter.JsonClassWriter
     {
-        public void write(Object obj, boolean showType, Writer output) throws IOException
+        @Override
+		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             TimeZone cal = (TimeZone) obj;
-            output.write("\"zone\":\"");
-            output.write(cal.getID());
-            output.write('"');
+            output.append("\"zone\":\"");
+            output.append(cal.getID());
+            output.append('"');
         }
 
-        public boolean hasPrimitiveForm() { return false; }
-        public void writePrimitiveForm(Object o, Writer output) throws IOException {}
+        @Override
+		public boolean hasPrimitiveForm() { return false; }
+        @Override
+		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException {}
     }
 
     public static class CalendarWriter implements JsonWriter.JsonClassWriter
     {
-        public void write(Object obj, boolean showType, Writer output) throws IOException
+        @Override
+		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             Calendar cal = (Calendar) obj;
             MetaUtils.dateFormat.get().setTimeZone(cal.getTimeZone());
-            output.write("\"time\":\"");
-            output.write(MetaUtils.dateFormat.get().format(cal.getTime()));
-            output.write("\",\"zone\":\"");
-            output.write(cal.getTimeZone().getID());
-            output.write('"');
+            output.append("\"time\":\"");
+            output.append(MetaUtils.dateFormat.get().format(cal.getTime()));
+            output.append("\",\"zone\":\"");
+            output.append(cal.getTimeZone().getID());
+            output.append('"');
         }
 
-        public boolean hasPrimitiveForm() { return false; }
-        public void writePrimitiveForm(Object o, Writer output) throws IOException {}
+        @Override
+		public boolean hasPrimitiveForm() { return false; }
+        @Override
+		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException {}
     }
 
     public static class DateWriter implements JsonWriter.JsonClassWriter, JsonWriter.JsonClassWriterEx
     {
-        public void write(Object obj, boolean showType, Writer output) throws IOException
+        @Override
+		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             throw new JsonIoException("Should never be called.");
         }
 
-        public void write(Object obj, boolean showType, Writer output, Map args) throws IOException
+        @Override
+		public void write(Object obj, boolean showType, final StringBuilder output, Map args) throws IOException
         {
             Date date = (Date)obj;
             Object dateFormat = args.get(DATE_FORMAT);
@@ -90,29 +97,31 @@ public class Writers
             }
             if (showType)
             {
-                output.write("\"value\":");
+                output.append("\"value\":");
             }
 
             if (dateFormat instanceof Format)
             {
-                output.write("\"");
-                output.write(((Format) dateFormat).format(date));
-                output.write("\"");
+                output.append("\"");
+                output.append(((Format) dateFormat).format(date));
+                output.append("\"");
             }
             else
             {
-                output.write(Long.toString(((Date) obj).getTime()));
+                output.append(Long.toString(((Date) obj).getTime()));
             }
         }
 
-        public boolean hasPrimitiveForm() { return true; }
+        @Override
+		public boolean hasPrimitiveForm() { return true; }
 
-        public void writePrimitiveForm(Object o, Writer output) throws IOException
+        @Override
+		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             throw new JsonIoException("Should never be called.");
         }
 
-        public void writePrimitiveForm(Object o, Writer output, Map args) throws IOException
+        public void writePrimitiveForm(Object o, final StringBuilder output, Map args) throws IOException
         {
             if (args.containsKey(DATE_FORMAT))
             {
@@ -120,40 +129,46 @@ public class Writers
             }
             else
             {
-                output.write(Long.toString(((Date) o).getTime()));
+                output.append(Long.toString(((Date) o).getTime()));
             }
         }
     }
 
     public static class TimestampWriter implements JsonWriter.JsonClassWriter
     {
-        public void write(Object o, boolean showType, Writer output) throws IOException
+        @Override
+		public void write(Object o, boolean showType, final StringBuilder output) throws IOException
         {
             Timestamp tstamp = (Timestamp) o;
-            output.write("\"time\":\"");
-            output.write(Long.toString((tstamp.getTime() / 1000) * 1000));
-            output.write("\",\"nanos\":\"");
-            output.write(Integer.toString(tstamp.getNanos()));
-            output.write('"');
+            output.append("\"time\":\"");
+            output.append(Long.toString((tstamp.getTime() / 1000) * 1000));
+            output.append("\",\"nanos\":\"");
+            output.append(Integer.toString(tstamp.getNanos()));
+            output.append('"');
         }
 
-        public boolean hasPrimitiveForm() { return false; }
+        @Override
+		public boolean hasPrimitiveForm() { return false; }
 
-        public void writePrimitiveForm(Object o, Writer output) throws IOException { }
+        @Override
+		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException { }
     }
 
     public static class ClassWriter implements JsonWriter.JsonClassWriter
     {
-        public void write(Object obj, boolean showType, Writer output) throws IOException
+        @Override
+		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             String value = ((Class) obj).getName();
-            output.write("\"value\":");
+            output.append("\"value\":");
             writeJsonUtf8String(value, output);
         }
 
-        public boolean hasPrimitiveForm() { return true; }
+        @Override
+		public boolean hasPrimitiveForm() { return true; }
 
-        public void writePrimitiveForm(Object o, Writer output) throws IOException
+        @Override
+		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             writeJsonUtf8String(((Class)o).getName(), output);
         }
@@ -161,15 +176,18 @@ public class Writers
 
     public static class JsonStringWriter implements JsonWriter.JsonClassWriter
     {
-        public void write(Object obj, boolean showType, Writer output) throws IOException
+        @Override
+		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
-            output.write("\"value\":");
+            output.append("\"value\":");
             writeJsonUtf8String((String) obj, output);
         }
 
-        public boolean hasPrimitiveForm() { return true; }
+        @Override
+		public boolean hasPrimitiveForm() { return true; }
 
-        public void writePrimitiveForm(Object o, Writer output) throws IOException
+        @Override
+		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             writeJsonUtf8String((String) o, output);
         }
@@ -177,32 +195,36 @@ public class Writers
 
     public static class LocaleWriter implements JsonWriter.JsonClassWriter
     {
-        public void write(Object obj, boolean showType, Writer output) throws IOException
+        @Override
+		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             Locale locale = (Locale) obj;
 
-            output.write("\"language\":\"");
-            output.write(locale.getLanguage());
-            output.write("\",\"country\":\"");
-            output.write(locale.getCountry());
-            output.write("\",\"variant\":\"");
-            output.write(locale.getVariant());
-            output.write('"');
+            output.append("\"language\":\"");
+            output.append(locale.getLanguage());
+            output.append("\",\"country\":\"");
+            output.append(locale.getCountry());
+            output.append("\",\"variant\":\"");
+            output.append(locale.getVariant());
+            output.append('"');
         }
-        public boolean hasPrimitiveForm() { return false; }
-        public void writePrimitiveForm(Object o, Writer output) throws IOException { }
+        @Override
+		public boolean hasPrimitiveForm() { return false; }
+        @Override
+		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException { }
     }
 
     public static class BigIntegerWriter implements JsonWriter.JsonClassWriter
     {
-        public void write(Object obj, boolean showType, Writer output) throws IOException
+        @Override
+		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             if (showType)
             {
                 BigInteger big = (BigInteger) obj;
-                output.write("\"value\":\"");
-                output.write(big.toString(10));
-                output.write('"');
+                output.append("\"value\":\"");
+                output.append(big.toString(10));
+                output.append('"');
             }
             else
             {
@@ -210,26 +232,29 @@ public class Writers
             }
         }
 
-        public boolean hasPrimitiveForm() { return true; }
+        @Override
+		public boolean hasPrimitiveForm() { return true; }
 
-        public void writePrimitiveForm(Object o, Writer output) throws IOException
+        @Override
+		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             BigInteger big = (BigInteger) o;
-            output.write('"');
-            output.write(big.toString(10));
-            output.write('"');
+            output.append('"');
+            output.append(big.toString(10));
+            output.append('"');
         }
     }
 
     public static class AtomicBooleanWriter implements JsonWriter.JsonClassWriter
     {
-        public void write(Object obj, boolean showType, Writer output) throws IOException
+        @Override
+		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             if (showType)
             {
                 AtomicBoolean value = (AtomicBoolean) obj;
-                output.write("\"value\":");
-                output.write(value.toString());
+                output.append("\"value\":");
+                output.append(value.toString());
             }
             else
             {
@@ -237,24 +262,27 @@ public class Writers
             }
         }
 
-        public boolean hasPrimitiveForm() { return true; }
+        @Override
+		public boolean hasPrimitiveForm() { return true; }
 
-        public void writePrimitiveForm(Object o, Writer output) throws IOException
+        @Override
+		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             AtomicBoolean value = (AtomicBoolean) o;
-            output.write(value.toString());
+            output.append(value.toString());
         }
     }
 
     public static class AtomicIntegerWriter implements JsonWriter.JsonClassWriter
     {
-        public void write(Object obj, boolean showType, Writer output) throws IOException
+        @Override
+		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             if (showType)
             {
                 AtomicInteger value = (AtomicInteger) obj;
-                output.write("\"value\":");
-                output.write(value.toString());
+                output.append("\"value\":");
+                output.append(value.toString());
             }
             else
             {
@@ -262,24 +290,27 @@ public class Writers
             }
         }
 
-        public boolean hasPrimitiveForm() { return true; }
+        @Override
+		public boolean hasPrimitiveForm() { return true; }
 
-        public void writePrimitiveForm(Object o, Writer output) throws IOException
+        @Override
+		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             AtomicInteger value = (AtomicInteger) o;
-            output.write(value.toString());
+            output.append(value.toString());
         }
     }
 
     public static class AtomicLongWriter implements JsonWriter.JsonClassWriter
     {
-        public void write(Object obj, boolean showType, Writer output) throws IOException
+        @Override
+		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             if (showType)
             {
                 AtomicLong value = (AtomicLong) obj;
-                output.write("\"value\":");
-                output.write(value.toString());
+                output.append("\"value\":");
+                output.append(value.toString());
             }
             else
             {
@@ -287,25 +318,28 @@ public class Writers
             }
         }
 
-        public boolean hasPrimitiveForm() { return true; }
+        @Override
+		public boolean hasPrimitiveForm() { return true; }
 
-        public void writePrimitiveForm(Object o, Writer output) throws IOException
+        @Override
+		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             AtomicLong value = (AtomicLong) o;
-            output.write(value.toString());
+            output.append(value.toString());
         }
     }
 
     public static class BigDecimalWriter implements JsonWriter.JsonClassWriter
     {
-        public void write(Object obj, boolean showType, Writer output) throws IOException
+        @Override
+		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             if (showType)
             {
                 BigDecimal big = (BigDecimal) obj;
-                output.write("\"value\":\"");
-                output.write(big.toPlainString());
-                output.write('"');
+                output.append("\"value\":\"");
+                output.append(big.toPlainString());
+                output.append('"');
             }
             else
             {
@@ -313,63 +347,71 @@ public class Writers
             }
         }
 
-        public boolean hasPrimitiveForm() { return true; }
+        @Override
+		public boolean hasPrimitiveForm() { return true; }
 
-        public void writePrimitiveForm(Object o, Writer output) throws IOException
+        @Override
+		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             BigDecimal big = (BigDecimal) o;
-            output.write('"');
-            output.write(big.toPlainString());
-            output.write('"');
+            output.append('"');
+            output.append(big.toPlainString());
+            output.append('"');
         }
     }
 
     public static class StringBuilderWriter implements JsonWriter.JsonClassWriter
     {
-        public void write(Object obj, boolean showType, Writer output) throws IOException
+        @Override
+		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             StringBuilder builder = (StringBuilder) obj;
-            output.write("\"value\":\"");
-            output.write(builder.toString());
-            output.write('"');
+            output.append("\"value\":\"");
+            output.append(builder.toString());
+            output.append('"');
         }
 
-        public boolean hasPrimitiveForm() { return true; }
+        @Override
+		public boolean hasPrimitiveForm() { return true; }
 
-        public void writePrimitiveForm(Object o, Writer output) throws IOException
+        @Override
+		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             StringBuilder builder = (StringBuilder) o;
-            output.write('"');
-            output.write(builder.toString());
-            output.write('"');
+            output.append('"');
+            output.append(builder.toString());
+            output.append('"');
         }
     }
 
     public static class StringBufferWriter implements JsonWriter.JsonClassWriter
     {
-        public void write(Object obj, boolean showType, Writer output) throws IOException
+        @Override
+		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             StringBuffer buffer = (StringBuffer) obj;
-            output.write("\"value\":\"");
-            output.write(buffer.toString());
-            output.write('"');
+            output.append("\"value\":\"");
+            output.append(buffer.toString());
+            output.append('"');
         }
 
-        public boolean hasPrimitiveForm() { return true; }
+        @Override
+		public boolean hasPrimitiveForm() { return true; }
 
-        public void writePrimitiveForm(Object o, Writer output) throws IOException
+        @Override
+		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             StringBuffer buffer = (StringBuffer) o;
-            output.write('"');
-            output.write(buffer.toString());
-            output.write('"');
+            output.append('"');
+            output.append(buffer.toString());
+            output.append('"');
         }
     }
 
     // ========== Maintain knowledge about relationships below this line ==========
     static final String DATE_FORMAT = JsonWriter.DATE_FORMAT;
 
-    protected static void writeJsonUtf8String(String s, final Writer output) throws IOException
+    protected static void writeJsonUtf8String(String s, final StringBuilder output) throws IOException
     {
         JsonWriter.writeJsonUtf8String(s, output);
     }

--- a/src/main/java/com/cedarsoftware/util/io/Writers.java
+++ b/src/main/java/com/cedarsoftware/util/io/Writers.java
@@ -43,7 +43,7 @@ public class Writers
     public static class TimeZoneWriter implements JsonWriter.JsonClassWriter
     {
         @Override
-		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
+        public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             TimeZone cal = (TimeZone) obj;
             output.append("\"zone\":\"");
@@ -52,15 +52,15 @@ public class Writers
         }
 
         @Override
-		public boolean hasPrimitiveForm() { return false; }
+        public boolean hasPrimitiveForm() { return false; }
         @Override
-		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException {}
+        public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException {}
     }
 
     public static class CalendarWriter implements JsonWriter.JsonClassWriter
     {
         @Override
-		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
+		  public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             Calendar cal = (Calendar) obj;
             MetaUtils.dateFormat.get().setTimeZone(cal.getTimeZone());
@@ -72,21 +72,21 @@ public class Writers
         }
 
         @Override
-		public boolean hasPrimitiveForm() { return false; }
+		  public boolean hasPrimitiveForm() { return false; }
         @Override
-		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException {}
+		  public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException {}
     }
 
     public static class DateWriter implements JsonWriter.JsonClassWriter, JsonWriter.JsonClassWriterEx
     {
         @Override
-		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
+        public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             throw new JsonIoException("Should never be called.");
         }
 
         @Override
-		public void write(Object obj, boolean showType, final StringBuilder output, Map args) throws IOException
+        public void write(Object obj, boolean showType, final StringBuilder output, Map args) throws IOException
         {
             Date date = (Date)obj;
             Object dateFormat = args.get(DATE_FORMAT);
@@ -113,10 +113,10 @@ public class Writers
         }
 
         @Override
-		public boolean hasPrimitiveForm() { return true; }
+        public boolean hasPrimitiveForm() { return true; }
 
         @Override
-		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
+        public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             throw new JsonIoException("Should never be called.");
         }
@@ -137,7 +137,7 @@ public class Writers
     public static class TimestampWriter implements JsonWriter.JsonClassWriter
     {
         @Override
-		public void write(Object o, boolean showType, final StringBuilder output) throws IOException
+        public void write(Object o, boolean showType, final StringBuilder output) throws IOException
         {
             Timestamp tstamp = (Timestamp) o;
             output.append("\"time\":\"");
@@ -148,16 +148,16 @@ public class Writers
         }
 
         @Override
-		public boolean hasPrimitiveForm() { return false; }
+        public boolean hasPrimitiveForm() { return false; }
 
         @Override
-		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException { }
+        public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException { }
     }
 
     public static class ClassWriter implements JsonWriter.JsonClassWriter
     {
         @Override
-		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
+        public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             String value = ((Class) obj).getName();
             output.append("\"value\":");
@@ -165,10 +165,10 @@ public class Writers
         }
 
         @Override
-		public boolean hasPrimitiveForm() { return true; }
+		  public boolean hasPrimitiveForm() { return true; }
 
         @Override
-		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
+        public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             writeJsonUtf8String(((Class)o).getName(), output);
         }
@@ -177,17 +177,17 @@ public class Writers
     public static class JsonStringWriter implements JsonWriter.JsonClassWriter
     {
         @Override
-		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
+        public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             output.append("\"value\":");
             writeJsonUtf8String((String) obj, output);
         }
 
         @Override
-		public boolean hasPrimitiveForm() { return true; }
+        public boolean hasPrimitiveForm() { return true; }
 
         @Override
-		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
+        public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             writeJsonUtf8String((String) o, output);
         }
@@ -196,7 +196,7 @@ public class Writers
     public static class LocaleWriter implements JsonWriter.JsonClassWriter
     {
         @Override
-		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
+        public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             Locale locale = (Locale) obj;
 
@@ -209,15 +209,15 @@ public class Writers
             output.append('"');
         }
         @Override
-		public boolean hasPrimitiveForm() { return false; }
+        public boolean hasPrimitiveForm() { return false; }
         @Override
-		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException { }
+        public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException { }
     }
 
     public static class BigIntegerWriter implements JsonWriter.JsonClassWriter
     {
         @Override
-		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
+        public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             if (showType)
             {
@@ -233,10 +233,10 @@ public class Writers
         }
 
         @Override
-		public boolean hasPrimitiveForm() { return true; }
+        public boolean hasPrimitiveForm() { return true; }
 
         @Override
-		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
+        public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             BigInteger big = (BigInteger) o;
             output.append('"');
@@ -248,7 +248,7 @@ public class Writers
     public static class AtomicBooleanWriter implements JsonWriter.JsonClassWriter
     {
         @Override
-		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
+        public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             if (showType)
             {
@@ -263,10 +263,10 @@ public class Writers
         }
 
         @Override
-		public boolean hasPrimitiveForm() { return true; }
+        public boolean hasPrimitiveForm() { return true; }
 
         @Override
-		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
+        public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             AtomicBoolean value = (AtomicBoolean) o;
             output.append(value.toString());
@@ -276,7 +276,7 @@ public class Writers
     public static class AtomicIntegerWriter implements JsonWriter.JsonClassWriter
     {
         @Override
-		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
+        public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             if (showType)
             {
@@ -291,10 +291,10 @@ public class Writers
         }
 
         @Override
-		public boolean hasPrimitiveForm() { return true; }
+        public boolean hasPrimitiveForm() { return true; }
 
         @Override
-		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
+        public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             AtomicInteger value = (AtomicInteger) o;
             output.append(value.toString());
@@ -304,7 +304,7 @@ public class Writers
     public static class AtomicLongWriter implements JsonWriter.JsonClassWriter
     {
         @Override
-		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
+        public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             if (showType)
             {
@@ -319,10 +319,10 @@ public class Writers
         }
 
         @Override
-		public boolean hasPrimitiveForm() { return true; }
+        public boolean hasPrimitiveForm() { return true; }
 
         @Override
-		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
+        public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             AtomicLong value = (AtomicLong) o;
             output.append(value.toString());
@@ -332,7 +332,7 @@ public class Writers
     public static class BigDecimalWriter implements JsonWriter.JsonClassWriter
     {
         @Override
-		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
+        public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             if (showType)
             {
@@ -348,10 +348,10 @@ public class Writers
         }
 
         @Override
-		public boolean hasPrimitiveForm() { return true; }
+        public boolean hasPrimitiveForm() { return true; }
 
         @Override
-		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
+        public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             BigDecimal big = (BigDecimal) o;
             output.append('"');
@@ -363,7 +363,7 @@ public class Writers
     public static class StringBuilderWriter implements JsonWriter.JsonClassWriter
     {
         @Override
-		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
+        public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             StringBuilder builder = (StringBuilder) obj;
             output.append("\"value\":\"");
@@ -372,10 +372,10 @@ public class Writers
         }
 
         @Override
-		public boolean hasPrimitiveForm() { return true; }
+        public boolean hasPrimitiveForm() { return true; }
 
         @Override
-		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
+        public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             StringBuilder builder = (StringBuilder) o;
             output.append('"');
@@ -387,7 +387,7 @@ public class Writers
     public static class StringBufferWriter implements JsonWriter.JsonClassWriter
     {
         @Override
-		public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
+        public void write(Object obj, boolean showType, final StringBuilder output) throws IOException
         {
             StringBuffer buffer = (StringBuffer) obj;
             output.append("\"value\":\"");
@@ -396,10 +396,10 @@ public class Writers
         }
 
         @Override
-		public boolean hasPrimitiveForm() { return true; }
+        public boolean hasPrimitiveForm() { return true; }
 
         @Override
-		public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
+        public void writePrimitiveForm(Object o, final StringBuilder output) throws IOException
         {
             StringBuffer buffer = (StringBuffer) o;
             output.append('"');

--- a/src/test/groovy/com/cedarsoftware/util/io/TestCollection.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestCollection.groovy
@@ -1,13 +1,13 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
-
-import java.awt.Point
-
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertNull
 import static org.junit.Assert.assertTrue
+
+import java.awt.Point
+
+import org.junit.Test
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -33,10 +33,10 @@ class TestCollection
 
     private static enum TestEnum4
     {
-        A, B, C;
+        A, B, C
 
-        private int internal = 6;
-        protected long age = 21;
+        private int internal = 6
+        protected long age = 21
         String foo = "bar"
     }
 
@@ -57,7 +57,7 @@ class TestCollection
 
     static class PointList
     {
-        List<Point> points;
+        List<Point> points
     }
 
     static class EmptyArrayList
@@ -67,26 +67,26 @@ class TestCollection
 
     private static class ManyCollections implements Serializable
     {
-        private Collection[] _cols;
-        private List _strings_a;
-        private List _strings_b;
-        private List _strings_c;
-        private List _dates_a;
-        private List _dates_b;
-        private List _dates_c;
-        private List _classes_a;
-        private List _classes_b;
-        private List _classes_c;
-        private List _sb_a;
-        private List _sb_b;
-        private List _sb_c;
-        private List _poly_a;
-        private ArrayList _typedCol;
-        private Set _strs_a;
-        private Set _strs_b;
-        private Set _strs_c;
-        private Set _strs_d;
-        private HashSet _typedSet;
+        private Collection[] _cols
+        private List _strings_a
+        private List _strings_b
+        private List _strings_c
+        private List _dates_a
+        private List _dates_b
+        private List _dates_c
+        private List _classes_a
+        private List _classes_b
+        private List _classes_c
+        private List _sb_a
+        private List _sb_b
+        private List _sb_c
+        private List _poly_a
+        private ArrayList _typedCol
+        private Set _strs_a
+        private Set _strs_b
+        private Set _strs_c
+        private Set _strs_d
+        private HashSet _typedSet
 
         private void init()
         {
@@ -108,7 +108,7 @@ class TestCollection
             tree.add(new Integer(Integer.MAX_VALUE))
             tree.add(_CONST_INT)
 
-            _cols = [array, set, tree] as Collection[];
+            _cols = [array, set, tree] as Collection[]
 
             _strings_a = new LinkedList()
             _strings_a.add("Alpha")
@@ -116,7 +116,7 @@ class TestCollection
             _strings_a.add("Charlie")
             _strings_a.add("Delta")
             _strings_b = new LinkedList()
-            _strings_c = null;
+            _strings_c = null
 
             _dates_a = new ArrayList()
             _dates_a.add(new Date(0))
@@ -124,7 +124,7 @@ class TestCollection
             _dates_a.add(new Date(Long.MAX_VALUE))
             _dates_a.add(null)
             _dates_b = new ArrayList()
-            _dates_c = null;
+            _dates_c = null
 
             _classes_a = new ArrayList()
             _classes_a.add(boolean.class)
@@ -140,13 +140,13 @@ class TestCollection
             _classes_a.add(null)
             _classes_a.add(Class.class)
             _classes_b = new ArrayList()
-            _classes_c = null;
+            _classes_c = null
 
             _sb_a = new LinkedList()
             _sb_a.add(new StringBuffer("one"))
             _sb_a.add(new StringBuffer("two"))
             _sb_b = new LinkedList()
-            _sb_c = null;
+            _sb_c = null
 
             _poly_a = new ArrayList()
             _poly_a.add(Boolean.TRUE)
@@ -181,7 +181,7 @@ class TestCollection
             _strs_a.add("Bird")
             _strs_a.add("Goose")
             _strs_b = new HashSet()
-            _strs_c = null;
+            _strs_c = null
             _strs_d = new TreeSet()
             _strs_d.addAll(_strs_a)
 
@@ -216,8 +216,9 @@ class TestCollection
 
         assertCollection(root)
 
-        JsonWriter writer = new JsonWriter(new ByteArrayOutputStream())
-        writer.write(obj)
+//      JsonWriter writer = new JsonWriter(new ByteArrayOutputStream())
+		  JsonWriter writer = new JsonWriter()
+		  writer.write(obj)
         // TODO: Uncomment to test identity counter strategies (currently incremental + only referenced)
 //        System.out.TestUtil.printLine("writer._identity = " + writer._identity)
     }
@@ -229,16 +230,16 @@ class TestCollection
         assertTrue(root._cols[1].getClass().equals(HashSet.class))
         assertTrue(root._cols[2].getClass().equals(TreeSet.class))
 
-        Collection array = root._cols[0];
+        Collection array = root._cols[0]
         assertTrue(array.size() == 4)
         assertTrue(array.getClass().equals(ArrayList.class))
-        List alist = (List) array;
+        List alist = (List) array
         assertTrue(alist.get(0).equals(_testDate))
         assertTrue(alist.get(1).equals("Hello"))
         assertTrue(alist.get(2).equals(new TestObject("fudge")))
         assertTrue(alist.get(3).equals(_CONST_INT))
 
-        Collection set = root._cols[1];
+        Collection set = root._cols[1]
         assertTrue(set.size() == 4)
         assertTrue(set.getClass().equals(HashSet.class))
         assertTrue(set.contains(Map.class))
@@ -246,7 +247,7 @@ class TestCollection
         assertTrue(set.contains(null))
         assertTrue(set.contains(_CONST_INT))
 
-        set = root._cols[2];
+        set = root._cols[2]
         assertTrue(set.size() == 4)
         assertTrue(set.getClass().equals(TreeSet.class))
         assertTrue(set.contains(new Integer(Integer.MIN_VALUE)))
@@ -421,7 +422,7 @@ class TestCollection
         assertTrue(list.equals(list2))
 
         // Forward reference
-        String pkg = TestObject.class.name;
+        String pkg = TestObject.class.name
         json = '{"@type":"java.util.ArrayList","@items":[{"@ref":3},{"@id":3,"@type":"' + pkg + '","_name":"JSON","_other":null}]}'
         list2 = (List) JsonReader.jsonToJava(json)
         assertTrue(list.equals(list2))
@@ -478,7 +479,7 @@ class TestCollection
     @Test
     void testEmptyCollections()
     {
-        EmptyCols emptyCols;
+        EmptyCols emptyCols
         String className = TestCollection.class.getName()
         String json = '{"@type":"' + className + '$EmptyCols","col":{},"list":{},"map":{},"set":{},"sortedSet":{},"sortedMap":{}}'
         TestUtil.printLine("json = " + json)
@@ -501,7 +502,7 @@ class TestCollection
     @Test
     void testEnumWithPrivateMembersInCollection()
     {
-        TestEnum4 x = TestEnum4.B;
+        TestEnum4 x = TestEnum4.B
         List list = new ArrayList()
         list.add(x)
         String json = TestUtil.getJsonString(list)
@@ -509,11 +510,13 @@ class TestCollection
         String className = TestCollection.class.getName()
         assertEquals('{"@type":"java.util.ArrayList","@items":[{"@type":"' + className + '$TestEnum4","age":21,"foo":"bar","name":"B"}]}', json)
 
-        ByteArrayOutputStream ba = new ByteArrayOutputStream()
-        JsonWriter writer = new JsonWriter(ba, [(JsonWriter.ENUM_PUBLIC_ONLY):true])
-        writer.write(list)
-        json = new String(ba.toByteArray())
-        TestUtil.printLine(json)
+//      ByteArrayOutputStream ba = new ByteArrayOutputStream()
+//      JsonWriter writer = new JsonWriter(ba, [(JsonWriter.ENUM_PUBLIC_ONLY):true])
+		  JsonWriter writer = new JsonWriter([(JsonWriter.ENUM_PUBLIC_ONLY):true])
+//		  writer.write(list)
+//      json = new String(ba.toByteArray())
+		  json = writer.write(list)
+		  TestUtil.printLine(json)
         assertEquals('{"@type":"java.util.ArrayList","@items":[{"@type":"' + className + '$TestEnum4","name":"B"}]}', json)
     }
 
@@ -566,7 +569,7 @@ class TestCollection
         map = JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
         items = (Object[]) map.getArray()
         assertTrue(items.length == 1)
-        Object[] oa = (Object[]) items[0];
+        Object[] oa = (Object[]) items[0]
         assertTrue(oa.length == 4)
         assertTrue(oa[0].equals(123L))
         assertTrue(oa[1] == null)
@@ -611,7 +614,7 @@ class TestCollection
         Object[] oa = (Object[]) col1.get(5)
         assertTrue("dog".equals(oa[0]))
         assertTrue(oa[1] instanceof String[])
-        String[] sa = (String[]) oa[1];
+        String[] sa = (String[]) oa[1]
         assertTrue("a".equals(sa[0]))
         assertTrue("b".equals(sa[1]))
         assertTrue("c".equals(sa[2]))
@@ -634,7 +637,7 @@ class TestCollection
 
         assertTrue(json0.equals(json1))
 
-        Object[] list = [empty, empty];
+        Object[] list = [empty, empty]
         json0 = TestUtil.getJsonString(list)
         TestUtil.printLine("json0=" + json0)
 
@@ -642,8 +645,8 @@ class TestCollection
         assertTrue(array != null)
         list = array
         assertTrue(list.length == 2)
-        Map e1 = (Map) list[0];
-        Map e2 = (Map) list[1];
+        Map e1 = (Map) list[0]
+        Map e2 = (Map) list[1]
         assertTrue(e1.isEmpty())
         assertTrue(e2.isEmpty())
     }
@@ -651,7 +654,7 @@ class TestCollection
     @Test
     void testUntypedCollections()
     {
-        Object[] poly = ["Road Runner", 16L, 3.1415d, true, false, null, 7, "Coyote", "Coyote"] as Object[];
+        Object[] poly = ["Road Runner", 16L, 3.1415d, true, false, null, 7, "Coyote", "Coyote"] as Object[]
         String json = TestUtil.getJsonString(poly)
         TestUtil.printLine("json=" + json)
         assertTrue('["Road Runner",16,3.1415,true,false,null,{"@type":"int","value":7},"Coyote","Coyote"]'.equals(json))

--- a/src/test/groovy/com/cedarsoftware/util/io/TestConstructor.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestConstructor.groovy
@@ -1,10 +1,10 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
-
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNull
 import static org.junit.Assert.assertTrue
+
+import org.junit.Test
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -27,7 +27,7 @@ class TestConstructor
 {
     static class Canine
     {
-        String name;
+        String name
         Canine(Object nm)
         {
             name = nm.toString()     // intentionally causes NPE when reflective constructor tries 'null' as arg
@@ -36,10 +36,10 @@ class TestConstructor
 
     static class NoNullConstructor
     {
-        List list;
-        Map map;
-        String string;
-        Date date;
+        List list
+        Map map
+        String string
+        Date date
 
         private NoNullConstructor(List list, Map map, String string, Date date)
         {
@@ -47,19 +47,19 @@ class TestConstructor
             {
                 throw new JsonIoException("Constructor arguments cannot be null")
             }
-            this.list = list;
-            this.map = map;
-            this.string = string;
-            this.date = date;
+            this.list = list
+            this.map = map
+            this.string = string
+            this.date = date
         }
     }
 
     static class Web
     {
-        URL url;
+        URL url
         Web(URL u)
         {
-            url = u;
+            url = u
         }
     }
 
@@ -91,87 +91,87 @@ class TestConstructor
                                                      long l, Long L, float f, Float F, double d, Double D, boolean bool, Boolean Bool,
                                                      char c, Character C, String[] strings, int[] ints, BigDecimal bigD)
         {
-            _str = string;
-            _date = date;
-            _byte = b;
-            _Byte = B;
-            _short = s;
-            _Short = S;
-            _int = i;
-            _Integer = I;
-            _long = l;
-            _Long = L;
-            _float = f;
-            _Float = F;
-            _double = d;
-            _Double = D;
-            _boolean = bool;
-            _Boolean = Bool;
-            _char = c;
-            _Char = C;
-            _strings = strings;
-            _ints = ints;
-            _bigD = bigD;
+            _str = string
+            _date = date
+            _byte = b
+            _Byte = B
+            _short = s
+            _Short = S
+            _int = i
+            _Integer = I
+            _long = l
+            _Long = L
+            _float = f
+            _Float = F
+            _double = d
+            _Double = D
+            _boolean = bool
+            _Boolean = Bool
+            _char = c
+            _Char = C
+            _strings = strings
+            _ints = ints
+            _bigD = bigD
         }
 
         public String getString()
         {
-            return _str;
+            return _str
         }
 
         public Date getDate()
         {
-            return _date;
+            return _date
         }
 
         public byte getByte()
         {
-            return _byte;
+            return _byte
         }
 
         public short getShort()
         {
-            return _short;
+            return _short
         }
 
         public int getInt()
         {
-            return _int;
+            return _int
         }
 
         public long getLong()
         {
-            return _long;
+            return _long
         }
 
         public float getFloat()
         {
-            return _float;
+            return _float
         }
 
         public double getDouble()
         {
-            return _double;
+            return _double
         }
 
         public boolean getBoolean()
         {
-            return _boolean;
+            return _boolean
         }
 
         public char getChar()
         {
-            return _char;
+            return _char
         }
 
         public String[] getStrings()
         {
-            return _strings;
+            return _strings
         }
 
         public int[] getInts()
         {
-            return _ints;
+            return _ints
         }
     }
 
@@ -298,10 +298,10 @@ class TestConstructor
     void testNoNullConstructor()
     {
         NoNullConstructor noNull = new NoNullConstructor(new ArrayList(), [:], "", new Date())
-        noNull.list = null;
-        noNull.map = null;
-        noNull.string = null;
-        noNull.date = null;
+        noNull.list = null
+        noNull.map = null
+        noNull.string = null
+        noNull.date = null
 
         String json = TestUtil.getJsonString(noNull)
         TestUtil.printLine(json)
@@ -329,11 +329,13 @@ class TestConstructor
         Object o = JsonReader.jsonToJava(json)
         assert TestUtil.getJsonString(o) == json
 
-        ByteArrayOutputStream ba = new ByteArrayOutputStream()
-        JsonWriter writer = new JsonWriter(ba)
-        writer.write(o)
+// 	  ByteArrayOutputStream ba = new ByteArrayOutputStream()
+//      JsonWriter writer = new JsonWriter(ba)
+		  JsonWriter writer = new JsonWriter()
+//      writer.write(o)
+		  String s = writer.write(o)
         writer.close()
-        String s = new String(ba.toByteArray(), "UTF-8")
+//      String s = new String(ba.toByteArray(), "UTF-8")
         assert json == s
     }
 

--- a/src/test/groovy/com/cedarsoftware/util/io/TestCustomClassHandler.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestCustomClassHandler.groovy
@@ -1,11 +1,11 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import static org.junit.Assert.assertTrue
 
 import java.text.ParseException
 import java.text.SimpleDateFormat
 
-import static org.junit.Assert.assertTrue
+import org.junit.Test
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -35,26 +35,31 @@ class TestCustomClassHandler
 
     public class WeirdDateWriter implements JsonWriter.JsonClassWriter
     {
-        public void write(Object o, boolean showType, Writer out)
+		  @Override
+//      public void write(Object o, boolean showType, Writer out)
+		  public void write(Object o, boolean showType, final StringBuilder out) throws IOException
         {
             String value = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS").format((Date) o)
-            out.write("\"stuff\":\"")
-            out.write(value)
-            out.write('"')
+            out.append("\"stuff\":\"")
+            out.append(value)
+            out.append('"')
         }
 
         public boolean hasPrimitiveForm()
         {
-            return true;
+            return true
         }
 
-        public void writePrimitiveForm(Object o, Writer out)
+		  @Override
+//      public void writePrimitiveForm(Object o, Writer out)
+		  public void writePrimitiveForm(Object o, final StringBuilder out) throws IOException
         {
             String value = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS").format((Date) o)
-            out.write('"')
-            out.write(value)
-            out.write('"')
+            out.append('"')
+            out.append(value)
+            out.append('"')
         }
+
     }
 
     public class WeirdDateReader implements JsonReader.JsonClassReader

--- a/src/test/groovy/com/cedarsoftware/util/io/TestCustomWriter.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestCustomWriter.groovy
@@ -2,6 +2,7 @@ package com.cedarsoftware.util.io
 
 import org.junit.Test
 
+
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
  *         <br>
@@ -123,44 +124,48 @@ class TestCustomWriter
 
     static class CustomPersonWriter implements JsonWriter.JsonClassWriterEx
     {
-        void write(Object o, boolean showType, Writer output, Map<String, Object> args) throws IOException
-        {
+//      void write(Object o, boolean showType, Writer output, Map<String, Object> args) throws IOException
+		  public void write(Object o, boolean showType, final StringBuilder output, Map<String, Object> args) throws IOException 
+		  {
             Person p = (Person) o
-            output.write('"f":"')
-            output.write(p.getFirstName())
-            output.write('","l":"')
-            output.write(p.getLastName())
-            output.write('","p":[')
+            output.append('"f":"')
+            output.append(p.getFirstName())
+            output.append('","l":"')
+            output.append(p.getLastName())
+            output.append('","p":[')
 
             Iterator<Pet> i = p.getPets().iterator()
             while (i.hasNext())
             {
                 Pet pet = i.next()
-                output.write('{"n":"')
-                output.write(pet.name)
-                output.write('","t":"')
-                output.write(pet.type)
-                output.write('","a":')
-                output.write(pet.age.toString())
-                output.write('}')
+                output.append('{"n":"')
+                output.append(pet.name)
+                output.append('","t":"')
+                output.append(pet.type)
+                output.append('","a":')
+                output.append(pet.age.toString())
+                output.append('}')
                 if (i.hasNext())
                 {
-                    output.write(',');
+                    output.append(',')
                 }
             }
-            output.write(']');
+            output.append(']')
 
             assert JsonWriter.JsonClassWriterEx.Support.getWriter(args) instanceof JsonWriter
         }
+
     }
 
     static class CustomPersonWriterAddField implements JsonWriter.JsonClassWriterEx
     {
-        void write(Object o, boolean showType, Writer output, Map<String, Object> args) throws IOException
-        {
-            JsonWriter writer = JsonWriter.JsonClassWriterEx.Support.getWriter(args);
-            output.write("\"_version\":12,");
-            writer.writeObject(o, false, true);
+//      void write(Object o, boolean showType, Writer output, Map<String, Object> args) throws IOException
+   	  @Override
+        public void write(Object o, boolean showType, final StringBuilder output, Map<String, Object> args) throws IOException 
+   	  {
+            JsonWriter writer = JsonWriter.JsonClassWriterEx.Support.getWriter(args)
+            output.append("\"_version\":12,")
+            output.append(writer.getWrittenObject(o, false, true))
         }
     }
 
@@ -190,10 +195,13 @@ class TestCustomWriter
 
     static class BadCustomPWriter implements JsonWriter.JsonClassWriterEx
     {
-        void write(Object o, boolean showType, Writer output, Map<String, Object> args) throws IOException
-        {
-            throw new RuntimeException('Bad custom writer')
-        }
+
+		@Override
+//		void write(Object o, boolean showType, Writer output, Map<String, Object> args) throws IOException
+		public void write(Object o, boolean showType, final StringBuilder output, Map<String, Object> args) throws IOException 
+		{
+			throw new RuntimeException('Bad custom writer')
+		}
     }
 
     static Person createTestPerson()
@@ -290,7 +298,7 @@ class TestCustomWriter
     {
         Person p = createTestPerson()
         String jsonCustom = TestUtil.getJsonString(p, [(JsonWriter.CUSTOM_WRITER_MAP): [(Person.class): new CustomPersonWriterAddField()]])
-        assert jsonCustom.contains("_version\":12");
-        assert jsonCustom.contains("Michael");
+        assert jsonCustom.contains("_version\":12")
+        assert jsonCustom.contains("Michael")
     }
 }

--- a/src/test/groovy/com/cedarsoftware/util/io/TestEnums.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestEnums.groovy
@@ -1,11 +1,11 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import static org.junit.Assert.assertTrue
 
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 
-import static org.junit.Assert.assertTrue
+import org.junit.Test
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -45,13 +45,13 @@ class TestEnums
         },
         C(null) {
             void doXX() {}
-        };
+        }
 
         private final String val
 
         TestEnum3(String val)
         {
-            this.val = val;
+            this.val = val
         }
 
         abstract void doXX()
@@ -59,10 +59,10 @@ class TestEnums
 
     private static enum TestEnum4
     {
-        A, B, C;
+        A, B, C
 
-        private int internal = 6;
-        protected long age = 21;
+        private int internal = 6
+        protected long age = 21
         String foo = "bar"
     }
 
@@ -109,23 +109,25 @@ class TestEnums
     @Test
     void testEnumWithPrivateMembersAsField()
     {
-        TestEnum4 x = TestEnum4.B;
+        TestEnum4 x = TestEnum4.B
         String json = TestUtil.getJsonString(x)
         TestUtil.printLine(json)
         def className = TestEnum4.class.name
         assert '{"@type":"' + className + '","age":21,"foo":"bar","name":"B"}' == json
 
-        ByteArrayOutputStream ba = new ByteArrayOutputStream()
-        JsonWriter writer = new JsonWriter(ba, [(JsonWriter.ENUM_PUBLIC_ONLY): true])
-        writer.write(x)
-        json = new String(ba.toByteArray())
-        TestUtil.printLine(json)
+//      ByteArrayOutputStream ba = new ByteArrayOutputStream()
+//      JsonWriter writer = new JsonWriter(ba, [(JsonWriter.ENUM_PUBLIC_ONLY): true])
+		  JsonWriter writer = new JsonWriter([(JsonWriter.ENUM_PUBLIC_ONLY): true])
+//      writer.write(x)
+//      json = new String(ba.toByteArray())
+		  json = writer.write(x)
+		  TestUtil.printLine(json)
         assert '{"@type":"' + className + '","name":"B"}' == json
     }
 
     enum FederationStrategy
     {
-        EXCLUDE, FEDERATE_THIS, FEDERATE_ORIGIN;
+        EXCLUDE, FEDERATE_THIS, FEDERATE_ORIGIN
 
         static FederationStrategy fromName(String name)
         {

--- a/src/test/groovy/com/cedarsoftware/util/io/TestInternalAPIs.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestInternalAPIs.groovy
@@ -1,9 +1,9 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
-
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
+
+import org.junit.Test
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -26,9 +26,11 @@ class TestInternalAPIs
 {
     static class DerivedWriter extends JsonWriter
     {
-        public DerivedWriter(OutputStream out)
+//      public DerivedWriter(OutputStream out)
+		  public DerivedWriter()
         {
-            super(out)
+//         super(out)
+			  super()
         }
     }
 
@@ -58,9 +60,10 @@ class TestInternalAPIs
     @Test
     void testProtectedAPIs()
     {
-        ByteArrayOutputStream bao = new ByteArrayOutputStream()
-        DerivedWriter writer = new DerivedWriter(bao)
-        Map ref = writer.objectsReferenced
+//      ByteArrayOutputStream bao = new ByteArrayOutputStream()
+//      DerivedWriter writer = new DerivedWriter(bao)
+		  DerivedWriter writer = new DerivedWriter()
+		  Map ref = writer.objectsReferenced
         Map vis = writer.objectsVisited
         assertNotNull(ref)
         assertNotNull(vis)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestUtil.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestUtil.groovy
@@ -25,13 +25,13 @@ import java.nio.file.Paths
  */
 class TestUtil
 {
-    private static long totalJsonWrite;
-    private static long totalObjWrite;
-    private static long totalJsonRead;
-    private static long totalObjRead;
+    private static long totalJsonWrite
+    private static long totalObjWrite
+    private static long totalJsonRead
+    private static long totalObjRead
 
-    private static long outputStreamFailCount;
-    private static boolean debug = false;
+    private static long outputStreamFailCount
+    private static boolean debug = false
 
     static boolean isDebug() { return debug }
 
@@ -45,32 +45,35 @@ class TestUtil
 
     static String getJsonString(Object obj)
     {
-        return getJsonString(obj, [:]);
+        return getJsonString(obj, [:])
     }
 
     static String getJsonString(Object obj, Map<String, Object> args)
     {
-        ByteArrayOutputStream bout = new ByteArrayOutputStream()
-        JsonWriter jsonWriter = new JsonWriter(bout, args)
-        long startWrite1 = System.nanoTime()
-        jsonWriter.write(obj)
+//      ByteArrayOutputStream bout = new ByteArrayOutputStream()
+//      JsonWriter jsonWriter = new JsonWriter(bout, args)
+		  JsonWriter jsonWriter = new JsonWriter(args)
+		  long startWrite1 = System.nanoTime()
+//      jsonWriter.write(obj)
+		  String json = jsonWriter.write(obj)
         jsonWriter.flush()
         jsonWriter.close()
         long endWrite1 = System.nanoTime()
-        String json = new String(bout.toByteArray(), 'UTF-8')
+//      String json = new String(bout.toByteArray(), 'UTF-8')
 
         try
         {
-            bout = new ByteArrayOutputStream()
-            ObjectOutputStream out = new ObjectOutputStream(bout)
+//			   bout = new ByteArrayOutputStream()
+			   ByteArrayOutputStream bout = new ByteArrayOutputStream()
+				ObjectOutputStream out = new ObjectOutputStream(bout)
             long startWrite2 = System.nanoTime()
             out.writeObject(obj)
             out.flush()
             out.close()
             long endWrite2 = System.nanoTime()
 
-            totalJsonWrite += endWrite1 - startWrite1;
-            totalObjWrite += endWrite2 - startWrite2;
+            totalJsonWrite += endWrite1 - startWrite1
+            totalObjWrite += endWrite2 - startWrite2
             double t1 = (endWrite1 - startWrite1) / 1000000.0
             double t2 = (endWrite2 - startWrite2) / 1000000.0
             if (debug)
@@ -81,10 +84,10 @@ class TestUtil
         }
         catch (Exception e)
         {
-            outputStreamFailCount++;
+            outputStreamFailCount++
         }
 
-        return json;
+        return json
     }
 
     static Object readJsonObject(String json)
@@ -96,18 +99,18 @@ class TestUtil
     {
         long startRead1 = System.nanoTime()
 
-        ByteArrayInputStream ba;
+        ByteArrayInputStream ba
         try
         {
-            ba = new ByteArrayInputStream(json.getBytes("UTF-8"));
+            ba = new ByteArrayInputStream(json.getBytes("UTF-8"))
         }
         catch (UnsupportedEncodingException e)
         {
-            throw new JsonIoException("Could not convert JSON to Maps because your JVM does not support UTF-8", e);
+            throw new JsonIoException("Could not convert JSON to Maps because your JVM does not support UTF-8", e)
         }
-        JsonReader jr = new JsonReader(ba, args);
-        Object o = jr.readObject();
-        jr.close();
+        JsonReader jr = new JsonReader(ba, args)
+        Object o = jr.readObject()
+        jr.close()
 
         long endRead1 = System.nanoTime()
 
@@ -126,10 +129,10 @@ class TestUtil
             input.close()
             long endRead2 = System.nanoTime()
 
-            totalJsonRead += endRead1 - startRead1;
-            totalObjRead += endRead2 - startRead2;
-            double t1 = (endRead1 - startRead1) / 1000000.0;
-            double t2 = (endRead2 - startRead2) / 1000000.0;
+            totalJsonRead += endRead1 - startRead1
+            totalObjRead += endRead2 - startRead2
+            double t1 = (endRead1 - startRead1) / 1000000.0
+            double t2 = (endRead2 - startRead2) / 1000000.0
             if (debug)
             {
                 println("JSON  read time  = " + t1 + " ms")
@@ -138,10 +141,10 @@ class TestUtil
         }
         catch (Exception e)
         {
-            outputStreamFailCount++;
+            outputStreamFailCount++
         }
 
-        return o;
+        return o
     }
 
     static Map readJsonMap(String json, Map<String, Object> args)
@@ -163,8 +166,8 @@ class TestUtil
         }
         args[(JsonReader.USE_MAPS)] = true
         JsonReader jr = new JsonReader(ba, args)
-        Object o = jr.readObject();
-        jr.close();
+        Object o = jr.readObject()
+        jr.close()
 
         long endRead1 = System.nanoTime()
 
@@ -183,10 +186,10 @@ class TestUtil
             input.close()
             long endRead2 = System.nanoTime()
 
-            totalJsonRead += endRead1 - startRead1;
-            totalObjRead += endRead2 - startRead2;
-            double t1 = (endRead1 - startRead1) / 1000000.0;
-            double t2 = (endRead2 - startRead2) / 1000000.0;
+            totalJsonRead += endRead1 - startRead1
+            totalObjRead += endRead2 - startRead2
+            double t1 = (endRead1 - startRead1) / 1000000.0
+            double t2 = (endRead2 - startRead2) / 1000000.0
             if (debug)
             {
                 println("JSON  read time  = " + t1 + " ms")
@@ -195,17 +198,17 @@ class TestUtil
         }
         catch (Exception e)
         {
-            outputStreamFailCount++;
+            outputStreamFailCount++
         }
 
-        return o;
+        return o
     }
 
     static void printLine(String s)
     {
         if (debug)
         {
-            println s;
+            println s
         }
     }
 

--- a/src/test/groovy/com/cedarsoftware/util/io/TestWriters.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestWriters.groovy
@@ -1,9 +1,9 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
-
 import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertTrue
+
+import org.junit.Test
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -28,19 +28,19 @@ class TestWriters
     void testUnusedAPIs()
     {
         Writers.TimeZoneWriter tzw = new Writers.TimeZoneWriter()
-        tzw.writePrimitiveForm("", new StringWriter())
+        tzw.writePrimitiveForm("", new StringBuilder())
 
         Writers.CalendarWriter cw = new Writers.CalendarWriter()
-        cw.writePrimitiveForm("", new StringWriter())
+        cw.writePrimitiveForm("", new StringBuilder())
 
         Writers.TimestampWriter tsw = new Writers.TimestampWriter()
-        tsw.writePrimitiveForm("", new StringWriter())
+        tsw.writePrimitiveForm("", new StringBuilder())
 
         Writers.LocaleWriter lw = new Writers.LocaleWriter()
-        lw.writePrimitiveForm("", new StringWriter())
+        lw.writePrimitiveForm("", new StringBuilder())
 
         Writers.JsonStringWriter jsw = new Writers.JsonStringWriter()
-        jsw.write("", false, new StringWriter())
+        jsw.write("", false, new StringBuilder())
     }
 
     @Test

--- a/src/test/java/com/cedarsoftware/util/io/TestFlatStructureJSONGeneration.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestFlatStructureJSONGeneration.java
@@ -1,0 +1,184 @@
+package com.cedarsoftware.util.io;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+
+
+/**
+ * @author Jeremie Ratomposon (jratompo+jsonio@gmail.com) <br>
+ *         Copyright (c) Alqcodex <br>
+ * <br>
+ *         Licensed under the Apache License, Version 2.0 (the "License") you may not use this file except in compliance
+ *         with the License. You may obtain a copy of the License at <br>
+ * <br>
+ *         http://www.apache.org/licenses/LICENSE-2.0 <br>
+ * <br>
+ *         Unless required by applicable law or agreed to in writing, software distributed under the License is
+ *         distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ *         the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+public class TestFlatStructureJSONGeneration {
+
+
+	private static class FooClass {
+
+		private int attrInt = 0;
+		private String attrString = "";
+		private FooClass other = null;
+
+		FooClass(int attrInt, String attrString) {
+			this.attrInt = attrInt;
+			this.attrString = attrString;
+		}
+
+		public void setOther(FooClass other) {
+			this.other = other;
+		}
+	}
+
+	private static class FooClassWithCollection {
+
+		private int attrInt = 0;
+		private String attrString = "";
+		private Collection<FooClassWithCollection> others = null;
+
+		FooClassWithCollection(int attrInt, String attrString, Collection<FooClassWithCollection> others) {
+			this.attrInt = attrInt;
+			this.attrString = attrString;
+			this.others = others;
+		}
+
+		public void addOther(FooClassWithCollection other) {
+			this.others.add(other);
+		}
+	}
+
+	// =========================================
+
+	@Test
+	public void testCycleFlatMapJSONWritingAndBack() {
+
+		FooClass foo1 = new FooClass(11, "gru chaine 1");
+		FooClass foo2 = new FooClass(12, "gru chaine 2");
+		FooClass foo3 = new FooClass(13, "gru chaine 3");
+
+		foo1.setOther(foo2);
+		foo2.setOther(foo3);
+		// We introduce a cycle :
+		foo3.setOther(foo1);
+
+		// -------------
+
+		// We compare the two objects pairs using the normal mode JSON generation :
+		String foo1JSONStr = FlatMapTestUtils.getAsFlatJSON(foo1);
+		Object foo1Bis = FlatMapTestUtils.getAsTreeStructure(foo1JSONStr);
+
+		FlatMapTestUtils.assertEqualsWithNormalJSONWriting(foo1, foo1Bis);
+
+		// -------------
+
+		// We compare the two objects pairs using the normal mode JSON generation :
+		String foo2JSONStr = FlatMapTestUtils.getAsFlatJSON(foo2);
+		Object foo2Bis = FlatMapTestUtils.getAsTreeStructure(foo2JSONStr);
+
+		FlatMapTestUtils.assertEqualsWithNormalJSONWriting(foo2, foo2Bis);
+
+		// -------------
+
+		// We compare the two objects pairs using the normal mode JSON generation :
+
+		String foo3JSONStr = FlatMapTestUtils.getAsFlatJSON(foo3);
+		Object foo3Bis = FlatMapTestUtils.getAsTreeStructure(foo3JSONStr);
+
+		FlatMapTestUtils.assertEqualsWithNormalJSONWriting(foo3, foo3Bis);
+
+	}
+
+
+	@Test
+	public void testCycleWithArrayFlatMapJSONWritingAndBack() {
+
+		FooClassWithCollection foo1 = new FooClassWithCollection(11, "gru chaine 1", new ArrayList<>());
+		FooClassWithCollection foo2 = new FooClassWithCollection(12, "gru chaine 2", new ArrayList<>());
+		FooClassWithCollection foo3 = new FooClassWithCollection(13, "gru chaine 3", new ArrayList<>());
+
+		foo1.addOther(foo2);
+		foo2.addOther(foo3);
+		// We introduce a cycle :
+		foo3.addOther(foo1);
+
+		// -------------
+
+		// We compare the two objects pairs using the normal mode JSON generation :
+		String foo1JSONStr = FlatMapTestUtils.getAsFlatJSON(foo1);
+		Object foo1Bis = FlatMapTestUtils.getAsTreeStructure(foo1JSONStr);
+
+		FlatMapTestUtils.assertEqualsWithNormalJSONWriting(foo1, foo1Bis);
+
+		// -------------
+
+		// We compare the two objects pairs using the normal mode JSON generation :
+		String foo2JSONStr = FlatMapTestUtils.getAsFlatJSON(foo2);
+		Object foo2Bis = FlatMapTestUtils.getAsTreeStructure(foo2JSONStr);
+
+		FlatMapTestUtils.assertEqualsWithNormalJSONWriting(foo2, foo2Bis);
+
+		// -------------
+
+		// We compare the two objects pairs using the normal mode JSON generation :
+
+		String foo3JSONStr = FlatMapTestUtils.getAsFlatJSON(foo3);
+		Object foo3Bis = FlatMapTestUtils.getAsTreeStructure(foo3JSONStr);
+
+		FlatMapTestUtils.assertEqualsWithNormalJSONWriting(foo3, foo3Bis);
+
+	}
+
+	// =========================================
+
+	private static class FlatMapTestUtils {
+
+		static void assertEqualsWithNormalJSONWriting(Object object, Object objectBis) {
+			String objectJSONVerification = getAsJSON(object);
+			String objectBisJSONVerification = getAsJSON(objectBis);
+			assert objectJSONVerification.equals(objectBisJSONVerification);
+		}
+
+		static String getAsJSON(Object rawObject) {
+
+			Map<String, Object> params = new HashMap<>();
+
+			params.put(JsonWriter.TYPE, true);
+			params.put(JsonWriter.FLAT_STRUCTURE, true);
+			String jsonStr = JsonWriter.objectToJson(rawObject, params);
+
+			return jsonStr;
+		}
+
+		static String getAsFlatJSON(Object rawObject) {
+
+			Map<String, Object> params = new HashMap<>();
+
+			params.put(JsonWriter.TYPE, true);
+			params.put(JsonWriter.FLAT_STRUCTURE, true);
+			String jsonStr = JsonWriter.objectToJson(rawObject, params);
+
+			return jsonStr;
+		}
+
+		static Object getAsTreeStructure(String oldMapString) {
+			Map<Comparable, Object> result = (Map<Comparable, Object>) JsonReader.jsonToJava(oldMapString);
+			// First object is the root object :
+			return result.entrySet().iterator().next().getValue();
+		}
+
+	}
+
+}

--- a/src/test/java/com/cedarsoftware/util/io/TestFlatStructureJSONGeneration.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestFlatStructureJSONGeneration.java
@@ -105,9 +105,9 @@ public class TestFlatStructureJSONGeneration {
 	@Test
 	public void testCycleWithArrayFlatMapJSONWritingAndBack() {
 
-		FooClassWithCollection foo1 = new FooClassWithCollection(11, "gru chaine 1", new ArrayList<>());
-		FooClassWithCollection foo2 = new FooClassWithCollection(12, "gru chaine 2", new ArrayList<>());
-		FooClassWithCollection foo3 = new FooClassWithCollection(13, "gru chaine 3", new ArrayList<>());
+		FooClassWithCollection foo1 = new FooClassWithCollection(11, "gru chaine 1", new ArrayList<FooClassWithCollection>());
+		FooClassWithCollection foo2 = new FooClassWithCollection(12, "gru chaine 2", new ArrayList<FooClassWithCollection>());
+		FooClassWithCollection foo3 = new FooClassWithCollection(13, "gru chaine 3", new ArrayList<FooClassWithCollection>());
 
 		foo1.addOther(foo2);
 		foo2.addOther(foo3);


### PR DESCRIPTION
Added a render option (parameter «FLAT_STRUCTURE» : true/false) to render java objects graphs in a single-level nested JSON associative array : example : 

{
	"1": {
		"@id": 1,
		"@type": "com.cedarsoftware.util.io.TestFlatStructureJSONGeneration$FooClass",
		"attrInt": 11,
		"attrString": "gru chaine 1",
		"other": {
			"@ref": 2
		}
	},
	"2": {
		"@id": 2,
		"@type": "com.cedarsoftware.util.io.TestFlatStructureJSONGeneration$FooClass",
		"attrInt": 12,
		"attrString": "gru chaine 2",
		"other": {
			"@ref": 3
		}
	},
	"3": {
		"@id": 3,
		"@type": "com.cedarsoftware.util.io.TestFlatStructureJSONGeneration$FooClass",
		"attrInt": 13,
		"attrString": "gru chaine 3",
		"other": {
			"@ref": 1
		}
	}
}

This allows to make treatments without using a recursive discovery.
I had to replace the Writer as output holder with a StringBuilder for not having to rely on an external ByteArrayOutputStream, and because I had to change the rendering algorithm to use more than one output holder attribute.



