### PR TITLE
- support deserialization of Collections.EmptyList on JDK17

### DIFF
--- a/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
+++ b/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
@@ -483,6 +483,9 @@ public class MetaUtils
         {
             return new ArrayList();
         }
+        if (Collections.EMPTY_LIST.getClass().equals(c)) {
+            return Collections.emptyList();
+        }
 
         if (c.isInterface())
         {

--- a/src/main/java/com/cedarsoftware/util/io/Resolver.java
+++ b/src/main/java/com/cedarsoftware/util/io/Resolver.java
@@ -65,6 +65,7 @@ abstract class Resolver
         coercedTypes.put("java.util.concurrent.ConcurrentSkipListMap$Values", ArrayList.class);
         coercedTypes.put("java.util.IdentityHashMap$KeySet", LinkedHashSet.class);
         coercedTypes.put("java.util.IdentityHashMap$Values", ArrayList.class);
+        coercedTypes.put("java.util.Collections$EmptyList", Collections.EMPTY_LIST.getClass());
     }
 
     /**

--- a/src/test/java/com/cedarsoftware/util/io/TestEmptyListForJdk17.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestEmptyListForJdk17.java
@@ -1,0 +1,39 @@
+package com.cedarsoftware.util.io;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author John DeRegnaucourt (jdereg@gmail.com)
+ *         <br>
+ *         Copyright (c) Cedar Software LLC
+ *         <br><br>
+ *         Licensed under the Apache License, Version 2.0 (the "License")
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *         <br><br>
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *         <br><br>
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ */
+public class TestEmptyListForJdk17 {
+
+    @Test
+    public void testEmptyListJDK17() {
+        final Object o = Collections.emptyList();
+
+        String json = JsonWriter.objectToJson(o);
+        List es = (List) JsonReader.jsonToJava(json);
+
+        Assert.assertTrue(es.isEmpty());
+        Assert.assertEquals(Collections.EMPTY_LIST.getClass(), es.getClass());
+    }
+
+}


### PR DESCRIPTION
this will help to fix the issue with Collections.EmptyList on JDK 17

The problem:
```
Caused by: com.cedarsoftware.util.io.JsonIoException: Class listed in @type [java.util.Collections$EmptyList] is not found
	at com.cedarsoftware.util.io.ObjectResolver.readIfMatching(ObjectResolver.java:663)
	at com.cedarsoftware.util.io.ObjectResolver.assignField(ObjectResolver.java:176)
	... 69 more
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make private java.util.Collections$EmptyList() accessible: module j
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Constructor.checkCanSetAccessible(Constructor.java:188)
	at java.base/java.lang.reflect.Constructor.setAccessible(Constructor.java:181)
	at com.cedarsoftware.util.io.MetaUtils.tryOtherConstruction(MetaUtils.java:627)
	at com.cedarsoftware.util.io.MetaUtils.newInstanceEx(MetaUtils.java:570)
	at com.cedarsoftware.util.io.MetaUtils.newInstance(MetaUtils.java:540)
	at com.cedarsoftware.util.io.JsonReader.newInstance(JsonReader.java:799)
	at com.cedarsoftware.util.io.Resolver.newInstance(Resolver.java:664)
	at com.cedarsoftware.util.io.Resolver.createJavaObjectInstance(Resolver.java:393)
	at com.cedarsoftware.util.io.ObjectResolver.readIfMatching(ObjectResolver.java:659)

```

