### PR TITLE
Java 17 support for java.util.UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,96 +3,99 @@ json-io
 <!--[![Build Status](https://travis-ci.org/jdereg/json-io.svg?branch=master)](https://travis-ci.org/jdereg/json-io) -->
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.cedarsoftware/json-io/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.cedarsoftware/json-io)
 [![Javadoc](https://javadoc.io/badge/com.cedarsoftware/json-io.svg)](http://www.javadoc.io/doc/com.cedarsoftware/json-io)
+
 Perfect Java serialization to and from JSON format (available on [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cjson-io)). To include in your project:
+
     <dependency>
       <groupId>com.cedarsoftware</groupId>
       <artifactId>json-io</artifactId>
       <version>4.13.0</version>
     </dependency>
 ___
-**json-io** consists of two main classes, a reader (`JsonReader`) and a writer (`JsonWriter`).  **json-io** eliminates 
+**json-io** consists of two main classes, a reader (`JsonReader`) and a writer (`JsonWriter`).  **json-io** eliminates
 the need for using `ObjectInputStream / ObjectOutputStream` to serialize Java and instead uses the JSON format.
 
-**json-io** does not require that Java classes implement `Serializable` or `Externalizable` to be serialized, 
-unlike the JDK's `ObjectInputStream` / `ObjectOutputStream`.  It will serialize any Java object graph into JSON and retain 
-complete graph semantics / shape and object types.  This includes supporting private fields, private inner classes 
-(static or non-static), of any depth.  It also includes handling cyclic references.  Objects do not need to have 
-public constructors to be serialized.  The output JSON will not include `transient` fields, identical to the 
+**json-io** does not require that Java classes implement `Serializable` or `Externalizable` to be serialized,
+unlike the JDK's `ObjectInputStream` / `ObjectOutputStream`.  It will serialize any Java object graph into JSON and retain
+complete graph semantics / shape and object types.  This includes supporting private fields, private inner classes
+(static or non-static), of any depth.  It also includes handling cyclic references.  Objects do not need to have
+public constructors to be serialized.  The output JSON will not include `transient` fields, identical to the
 ObjectOutputStream behavior.
 
-**json-io** does not depend on any 3rd party libraries, has extensive support for Java Generics, and allows extensive customization. 
+**json-io** does not depend on any 3rd party libraries, has extensive support for Java Generics, and allows extensive customization.
 
 ### A few advantages of json-io over Google's gson library:
-* gson will fail with infinite recursion (`StackOverflowError`) when there is a cycle in the input data.  [Illustrated here.](https://github.com/jdereg/json-io/blob/master/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleCycleButJsonIoCan.java) 
+* gson will fail with infinite recursion (`StackOverflowError`) when there is a cycle in the input data.  [Illustrated here.](https://github.com/jdereg/json-io/blob/master/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleCycleButJsonIoCan.java)
 * gson cannot handle non-static inner classes. [Illustrated here.](https://github.com/jdereg/json-io/blob/master/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleStaticInnerButJsonIoCan.java)
 * gson cannot handle hetereogeneous `Collections`, `Object[]`, or `Maps`.  [Illustrated here.](https://github.com/jdereg/json-io/blob/master/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleHeteroCollections.java)
 * gson cannot handle Maps with keys that are not Strings. [Illustrated here.](https://github.com/jdereg/json-io/blob/master/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleMapWithNonStringKeysButJsonIoCan.java)
 
 ### Format
-**json-io** uses proper JSON format.  As little type information is included in the JSON format to keep it compact as 
-possible.  When an object's class can be inferred from a field type or array type, the object's type information is 
+**json-io** uses proper JSON format.  As little type information is included in the JSON format to keep it compact as
+possible.  When an object's class can be inferred from a field type or array type, the object's type information is
 left out of the stream.  For example, a `String[]` looks like `["abc", "xyz"]`.
 
 When an object's type must be emitted, it is emitted as a meta-object field `"@type":"package.class"` in the object.  
 When read, this tells the JsonReader what class to instantiate.  (`@type` output can be turned off - see [User Guide](/user-guide.md)).
 
-If an object is referenced more than once, or references an object that has not yet been defined, (say A points to B, 
-and B points to C, and C points to A), it emits a `"@ref":n` where 'n' is the object's integer identity (with a 
-corresponding meta entry `"@id":n` defined on the referenced object).  Only referenced objects have IDs in the JSON 
+If an object is referenced more than once, or references an object that has not yet been defined, (say A points to B,
+and B points to C, and C points to A), it emits a `"@ref":n` where 'n' is the object's integer identity (with a
+corresponding meta entry `"@id":n` defined on the referenced object).  Only referenced objects have IDs in the JSON
 output, reducing the JSON String length.
 
 ### Performance
 **json-io** was written with performance in mind.  In most cases **json-io** is faster than the JDK's
- `ObjectInputStream / ObjectOutputStream`.  As the tests run, a log is written of the time it takes to 
- serialize / deserialize and compares it to `ObjectInputStream / ObjectOutputStream` (if the static 
- variable `_debug` is `true` in `TestUtil`).
- 
+`ObjectInputStream / ObjectOutputStream`.  As the tests run, a log is written of the time it takes to
+serialize / deserialize and compares it to `ObjectInputStream / ObjectOutputStream` (if the static
+variable `_debug` is `true` in `TestUtil`).
+
 ### [User Guide](/user-guide.md)
 
 ### Pretty-Printing JSON
-
-    
-          
-            
-    
-
-          
-    
-    
-  
 Use `JsonWriter.formatJson()` API to format a passed in JSON string to a nice, human readable format.  Also, when writing
 JSON data, use the `JsonWriter.objectToJson(o, args)` API, where args is a `Map` with a key of `JsonWriter.PRETTY_PRINT`
 and a value of 'true' (`boolean` or `String`).  When run this way, the JSON written by the `JsonWriter` will be formatted
 in a nice, human readable format.
+
 ### RESTful support
 **json-io** can be used as the fundamental data transfer method between a Javascript / JQuery / Ajax client and a web server
 in a RESTful fashion.
+
 See [json-command-servlet](https://github.com/jdereg/json-command-servlet) for a light-weight servlet that processes REST requests.
+
 ### Noteworthy
 For useful Java utilities, check out [java-util](http://github.com/jdereg/java-util)
+
 Featured on [json.org](http://json.org).
+
 [Revision History](/changelog.md)
 ___
 ### Sponsors
 [![Alt text](https://www.yourkit.com/images/yklogo.png "YourKit")](https://www.yourkit.com/.net/profiler/index.jsp)
+
 YourKit supports open source projects with its full-featured Java Profiler.
 YourKit, LLC is the creator of <a href="https://www.yourkit.com/java/profiler/index.jsp">YourKit Java Profiler</a>
 and <a href="https://www.yourkit.com/.net/profiler/index.jsp">YourKit .NET Profiler</a>,
 innovative and intelligent tools for profiling Java and .NET applications.
+
 <a href="https://www.jetbrains.com/idea/"><img alt="Intellij IDEA from JetBrains" src="https://s-media-cache-ak0.pinimg.com/236x/bd/f4/90/bdf49052dd79aa1e1fc2270a02ba783c.jpg" data-canonical-src="https://s-media-cache-ak0.pinimg.com/236x/bd/f4/90/bdf49052dd79aa1e1fc2270a02ba783c.jpg" width="100" height="100" /></a>
 **Intellij IDEA**
 ___
 ### License
 ```
 Copyright (c) 2007 Cedar Software LLC.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+
 by John DeRegnaucourt

--- a/README.md
+++ b/README.md
@@ -3,99 +3,96 @@ json-io
 <!--[![Build Status](https://travis-ci.org/jdereg/json-io.svg?branch=master)](https://travis-ci.org/jdereg/json-io) -->
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.cedarsoftware/json-io/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.cedarsoftware/json-io)
 [![Javadoc](https://javadoc.io/badge/com.cedarsoftware/json-io.svg)](http://www.javadoc.io/doc/com.cedarsoftware/json-io)
-
 Perfect Java serialization to and from JSON format (available on [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cjson-io)). To include in your project:
-
     <dependency>
       <groupId>com.cedarsoftware</groupId>
       <artifactId>json-io</artifactId>
       <version>4.13.0</version>
     </dependency>
 ___
-**json-io** consists of two main classes, a reader (`JsonReader`) and a writer (`JsonWriter`).  **json-io** eliminates
+**json-io** consists of two main classes, a reader (`JsonReader`) and a writer (`JsonWriter`).  **json-io** eliminates 
 the need for using `ObjectInputStream / ObjectOutputStream` to serialize Java and instead uses the JSON format.
 
-**json-io** does not require that Java classes implement `Serializable` or `Externalizable` to be serialized,
-unlike the JDK's `ObjectInputStream` / `ObjectOutputStream`.  It will serialize any Java object graph into JSON and retain
-complete graph semantics / shape and object types.  This includes supporting private fields, private inner classes
-(static or non-static), of any depth.  It also includes handling cyclic references.  Objects do not need to have
-public constructors to be serialized.  The output JSON will not include `transient` fields, identical to the
+**json-io** does not require that Java classes implement `Serializable` or `Externalizable` to be serialized, 
+unlike the JDK's `ObjectInputStream` / `ObjectOutputStream`.  It will serialize any Java object graph into JSON and retain 
+complete graph semantics / shape and object types.  This includes supporting private fields, private inner classes 
+(static or non-static), of any depth.  It also includes handling cyclic references.  Objects do not need to have 
+public constructors to be serialized.  The output JSON will not include `transient` fields, identical to the 
 ObjectOutputStream behavior.
 
-**json-io** does not depend on any 3rd party libraries, has extensive support for Java Generics, and allows extensive customization.
+**json-io** does not depend on any 3rd party libraries, has extensive support for Java Generics, and allows extensive customization. 
 
 ### A few advantages of json-io over Google's gson library:
-* gson will fail with infinite recursion (`StackOverflowError`) when there is a cycle in the input data.  [Illustrated here.](https://github.com/jdereg/json-io/blob/master/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleCycleButJsonIoCan.java)
+* gson will fail with infinite recursion (`StackOverflowError`) when there is a cycle in the input data.  [Illustrated here.](https://github.com/jdereg/json-io/blob/master/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleCycleButJsonIoCan.java) 
 * gson cannot handle non-static inner classes. [Illustrated here.](https://github.com/jdereg/json-io/blob/master/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleStaticInnerButJsonIoCan.java)
 * gson cannot handle hetereogeneous `Collections`, `Object[]`, or `Maps`.  [Illustrated here.](https://github.com/jdereg/json-io/blob/master/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleHeteroCollections.java)
 * gson cannot handle Maps with keys that are not Strings. [Illustrated here.](https://github.com/jdereg/json-io/blob/master/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleMapWithNonStringKeysButJsonIoCan.java)
 
 ### Format
-**json-io** uses proper JSON format.  As little type information is included in the JSON format to keep it compact as
-possible.  When an object's class can be inferred from a field type or array type, the object's type information is
+**json-io** uses proper JSON format.  As little type information is included in the JSON format to keep it compact as 
+possible.  When an object's class can be inferred from a field type or array type, the object's type information is 
 left out of the stream.  For example, a `String[]` looks like `["abc", "xyz"]`.
 
 When an object's type must be emitted, it is emitted as a meta-object field `"@type":"package.class"` in the object.  
 When read, this tells the JsonReader what class to instantiate.  (`@type` output can be turned off - see [User Guide](/user-guide.md)).
 
-If an object is referenced more than once, or references an object that has not yet been defined, (say A points to B,
-and B points to C, and C points to A), it emits a `"@ref":n` where 'n' is the object's integer identity (with a
-corresponding meta entry `"@id":n` defined on the referenced object).  Only referenced objects have IDs in the JSON
+If an object is referenced more than once, or references an object that has not yet been defined, (say A points to B, 
+and B points to C, and C points to A), it emits a `"@ref":n` where 'n' is the object's integer identity (with a 
+corresponding meta entry `"@id":n` defined on the referenced object).  Only referenced objects have IDs in the JSON 
 output, reducing the JSON String length.
 
 ### Performance
 **json-io** was written with performance in mind.  In most cases **json-io** is faster than the JDK's
-`ObjectInputStream / ObjectOutputStream`.  As the tests run, a log is written of the time it takes to
-serialize / deserialize and compares it to `ObjectInputStream / ObjectOutputStream` (if the static
-variable `_debug` is `true` in `TestUtil`).
-
+ `ObjectInputStream / ObjectOutputStream`.  As the tests run, a log is written of the time it takes to 
+ serialize / deserialize and compares it to `ObjectInputStream / ObjectOutputStream` (if the static 
+ variable `_debug` is `true` in `TestUtil`).
+ 
 ### [User Guide](/user-guide.md)
 
 ### Pretty-Printing JSON
+
+    
+          
+            
+    
+
+          
+    
+    
+  
 Use `JsonWriter.formatJson()` API to format a passed in JSON string to a nice, human readable format.  Also, when writing
 JSON data, use the `JsonWriter.objectToJson(o, args)` API, where args is a `Map` with a key of `JsonWriter.PRETTY_PRINT`
 and a value of 'true' (`boolean` or `String`).  When run this way, the JSON written by the `JsonWriter` will be formatted
 in a nice, human readable format.
-
 ### RESTful support
 **json-io** can be used as the fundamental data transfer method between a Javascript / JQuery / Ajax client and a web server
 in a RESTful fashion.
-
 See [json-command-servlet](https://github.com/jdereg/json-command-servlet) for a light-weight servlet that processes REST requests.
-
 ### Noteworthy
 For useful Java utilities, check out [java-util](http://github.com/jdereg/java-util)
-
 Featured on [json.org](http://json.org).
-
 [Revision History](/changelog.md)
 ___
 ### Sponsors
 [![Alt text](https://www.yourkit.com/images/yklogo.png "YourKit")](https://www.yourkit.com/.net/profiler/index.jsp)
-
 YourKit supports open source projects with its full-featured Java Profiler.
 YourKit, LLC is the creator of <a href="https://www.yourkit.com/java/profiler/index.jsp">YourKit Java Profiler</a>
 and <a href="https://www.yourkit.com/.net/profiler/index.jsp">YourKit .NET Profiler</a>,
 innovative and intelligent tools for profiling Java and .NET applications.
-
 <a href="https://www.jetbrains.com/idea/"><img alt="Intellij IDEA from JetBrains" src="https://s-media-cache-ak0.pinimg.com/236x/bd/f4/90/bdf49052dd79aa1e1fc2270a02ba783c.jpg" data-canonical-src="https://s-media-cache-ak0.pinimg.com/236x/bd/f4/90/bdf49052dd79aa1e1fc2270a02ba783c.jpg" width="100" height="100" /></a>
 **Intellij IDEA**
 ___
 ### License
 ```
 Copyright (c) 2007 Cedar Software LLC.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
-
 by John DeRegnaucourt

--- a/README.md
+++ b/README.md
@@ -12,43 +12,43 @@ Perfect Java serialization to and from JSON format (available on [Maven Central]
       <version>4.13.0</version>
     </dependency>
 ___
-**json-io** consists of two main classes, a reader (`JsonReader`) and a writer (`JsonWriter`).  **json-io** eliminates 
+**json-io** consists of two main classes, a reader (`JsonReader`) and a writer (`JsonWriter`).  **json-io** eliminates
 the need for using `ObjectInputStream / ObjectOutputStream` to serialize Java and instead uses the JSON format.
 
-**json-io** does not require that Java classes implement `Serializable` or `Externalizable` to be serialized, 
-unlike the JDK's `ObjectInputStream` / `ObjectOutputStream`.  It will serialize any Java object graph into JSON and retain 
-complete graph semantics / shape and object types.  This includes supporting private fields, private inner classes 
-(static or non-static), of any depth.  It also includes handling cyclic references.  Objects do not need to have 
-public constructors to be serialized.  The output JSON will not include `transient` fields, identical to the 
+**json-io** does not require that Java classes implement `Serializable` or `Externalizable` to be serialized,
+unlike the JDK's `ObjectInputStream` / `ObjectOutputStream`.  It will serialize any Java object graph into JSON and retain
+complete graph semantics / shape and object types.  This includes supporting private fields, private inner classes
+(static or non-static), of any depth.  It also includes handling cyclic references.  Objects do not need to have
+public constructors to be serialized.  The output JSON will not include `transient` fields, identical to the
 ObjectOutputStream behavior.
 
-**json-io** does not depend on any 3rd party libraries, has extensive support for Java Generics, and allows extensive customization. 
+**json-io** does not depend on any 3rd party libraries, has extensive support for Java Generics, and allows extensive customization.
 
 ### A few advantages of json-io over Google's gson library:
-* gson will fail with infinite recursion (`StackOverflowError`) when there is a cycle in the input data.  [Illustrated here.](https://github.com/jdereg/json-io/blob/master/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleCycleButJsonIoCan.java) 
+* gson will fail with infinite recursion (`StackOverflowError`) when there is a cycle in the input data.  [Illustrated here.](https://github.com/jdereg/json-io/blob/master/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleCycleButJsonIoCan.java)
 * gson cannot handle non-static inner classes. [Illustrated here.](https://github.com/jdereg/json-io/blob/master/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleStaticInnerButJsonIoCan.java)
 * gson cannot handle hetereogeneous `Collections`, `Object[]`, or `Maps`.  [Illustrated here.](https://github.com/jdereg/json-io/blob/master/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleHeteroCollections.java)
 * gson cannot handle Maps with keys that are not Strings. [Illustrated here.](https://github.com/jdereg/json-io/blob/master/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleMapWithNonStringKeysButJsonIoCan.java)
 
 ### Format
-**json-io** uses proper JSON format.  As little type information is included in the JSON format to keep it compact as 
-possible.  When an object's class can be inferred from a field type or array type, the object's type information is 
+**json-io** uses proper JSON format.  As little type information is included in the JSON format to keep it compact as
+possible.  When an object's class can be inferred from a field type or array type, the object's type information is
 left out of the stream.  For example, a `String[]` looks like `["abc", "xyz"]`.
 
 When an object's type must be emitted, it is emitted as a meta-object field `"@type":"package.class"` in the object.  
 When read, this tells the JsonReader what class to instantiate.  (`@type` output can be turned off - see [User Guide](/user-guide.md)).
 
-If an object is referenced more than once, or references an object that has not yet been defined, (say A points to B, 
-and B points to C, and C points to A), it emits a `"@ref":n` where 'n' is the object's integer identity (with a 
-corresponding meta entry `"@id":n` defined on the referenced object).  Only referenced objects have IDs in the JSON 
+If an object is referenced more than once, or references an object that has not yet been defined, (say A points to B,
+and B points to C, and C points to A), it emits a `"@ref":n` where 'n' is the object's integer identity (with a
+corresponding meta entry `"@id":n` defined on the referenced object).  Only referenced objects have IDs in the JSON
 output, reducing the JSON String length.
 
 ### Performance
 **json-io** was written with performance in mind.  In most cases **json-io** is faster than the JDK's
- `ObjectInputStream / ObjectOutputStream`.  As the tests run, a log is written of the time it takes to 
- serialize / deserialize and compares it to `ObjectInputStream / ObjectOutputStream` (if the static 
- variable `_debug` is `true` in `TestUtil`).
- 
+`ObjectInputStream / ObjectOutputStream`.  As the tests run, a log is written of the time it takes to
+serialize / deserialize and compares it to `ObjectInputStream / ObjectOutputStream` (if the static
+variable `_debug` is `true` in `TestUtil`).
+
 ### [User Guide](/user-guide.md)
 
 ### Pretty-Printing JSON

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.cedarsoftware</groupId>
     <artifactId>json-io</artifactId>
     <packaging>bundle</packaging>
-    <version>4.13.0</version>
+    <version>4.14.0-JDK17</version>
     <description>Java JSON serialization</description>
     <url>https://github.com/jdereg/json-io</url>
 
@@ -69,10 +69,10 @@
     </developers>
 
     <properties>
-        <version.java-util>1.37.0</version.java-util>           <!-- only test dependency -->
-        <version.junit>4.13.1</version.junit>                     <!-- only test dependency -->
-        <version.groovy>2.4.17</version.groovy>                  <!-- only test dependency -->
-        <version.gson>2.8.9</version.gson>                      <!-- only test dependency -->
+        <version.java-util>1.68.0</version.java-util>           <!-- only test dependency -->
+        <version.junit>4.13</version.junit>                     <!-- only test dependency -->
+        <version.groovy>2.5.14</version.groovy>                  <!-- only test dependency -->
+        <version.gson>2.9.1</version.gson>                      <!-- only test dependency -->
         <version.jmh>1.21</version.jmh>                       <!-- only test dependency -->
         <version.plugin.compiler>3.8.1</version.plugin.compiler>
         <version.plugin.nexus>1.6.8</version.plugin.nexus>
@@ -80,8 +80,8 @@
         <version.plugin.javadoc>3.1.1</version.plugin.javadoc>
         <version.plugin.gpg>1.6</version.plugin.gpg>
         <version.plugin.surefire>2.22.2</version.plugin.surefire>
-        <version.plugin.groovy.eclipse.compiler>3.5.0-01</version.plugin.groovy.eclipse.compiler>
-        <version.plugin.groovy.eclipse.batch>2.5.8-02</version.plugin.groovy.eclipse.batch>
+        <version.plugin.groovy.eclipse.compiler>3.6.0-01</version.plugin.groovy.eclipse.compiler>
+        <version.plugin.groovy.eclipse.batch>2.5.14-02</version.plugin.groovy.eclipse.batch>
         <version.plugin.felix.scr>1.26.2</version.plugin.felix.scr>
         <version.plugin.felix.bundle>4.2.1</version.plugin.felix.bundle>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -149,10 +149,13 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${version.plugin.compiler}</version>
                 <configuration>
-                    <release>7</release>
+                    <source>1.8</source>
+                    <target>1.8</target>
+<!--                    <release>1.8</release>-->
                     <compilerId>groovy-eclipse-compiler</compilerId>
                     <!-- <verbose>true</verbose> -->
                 </configuration>
@@ -291,6 +294,7 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>${version.groovy}</version>
+            <type>pom</type>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/cedarsoftware/util/io/JsonReader.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonReader.java
@@ -137,6 +137,7 @@ public class JsonReader implements Closeable
         temp.put(Class.class, new Readers.ClassReader());
         temp.put(StringBuilder.class, new Readers.StringBuilderReader());
         temp.put(StringBuffer.class, new Readers.StringBufferReader());
+        temp.put(UUID.class, new Readers.UUIDReader());
         BASE_READERS = temp;
     }
 

--- a/src/main/java/com/cedarsoftware/util/io/JsonWriter.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonWriter.java
@@ -142,6 +142,7 @@ public class JsonWriter implements Closeable, Flushable
         temp.put(Class.class, new Writers.ClassWriter());
         temp.put(StringBuilder.class, new Writers.StringBuilderWriter());
         temp.put(StringBuffer.class, new Writers.StringBufferWriter());
+        temp.put(UUID.class, new Writers.UUIDWriter());
         BASE_WRITERS = temp;
     }
 

--- a/src/main/java/com/cedarsoftware/util/io/Readers.java
+++ b/src/main/java/com/cedarsoftware/util/io/Readers.java
@@ -10,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -822,6 +823,36 @@ public class Readers
             tstamp.setNanos(Integer.valueOf((String) nanos));
             jObj.target = tstamp;
             return jObj.target;
+        }
+    }
+
+    public static class UUIDReader implements JsonReader.JsonClassReaderEx
+    {
+        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        {
+
+            // to use the String representation
+            if (o instanceof String)
+            {
+                return UUID.fromString((String) o);
+            }
+
+            JsonObject jObj = (JsonObject) o;
+            Long mostSigBits = (Long) jObj.get("mostSigBits");
+            if (mostSigBits == null)
+            {
+                throw new JsonIoException("java.util.UUID must specify 'mostSigBits' field");
+            }
+            Long leastSigBits = (Long) jObj.get("leastSigBits");
+            if (leastSigBits == null)
+            {
+                throw new JsonIoException("java.util.UUID must specify 'leastSigBits' field");
+            }
+
+            UUID uuid = new UUID(mostSigBits, leastSigBits);
+
+            jObj.setTarget(uuid);
+            return jObj.getTarget();
         }
     }
 

--- a/src/main/java/com/cedarsoftware/util/io/Writers.java
+++ b/src/main/java/com/cedarsoftware/util/io/Writers.java
@@ -12,6 +12,7 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -360,6 +361,35 @@ public class Writers
         public void writePrimitiveForm(Object o, Writer output) throws IOException
         {
             StringBuffer buffer = (StringBuffer) o;
+            output.write('"');
+            output.write(buffer.toString());
+            output.write('"');
+        }
+    }
+
+    public static class UUIDWriter implements JsonWriter.JsonClassWriter
+    {
+        /**
+         * To preserve backward compatibility with previous serialized format the internal fields must be stored as longs
+         */
+        public void write(Object obj, boolean showType, Writer output) throws IOException
+        {
+            UUID uuid = (UUID) obj;
+            output.write("\"mostSigBits\": ");
+            output.write(Long.toString(uuid.getMostSignificantBits()));
+            output.write(",\"leastSigBits\":");
+            output.write(Long.toString(uuid.getLeastSignificantBits()));
+        }
+
+        public boolean hasPrimitiveForm() { return true; }
+
+        /**
+         * We can use the String representation for easier handling, but this may break backwards compatibility
+         * if an earlier library version is used
+         */
+        public void writePrimitiveForm(Object o, Writer output) throws IOException
+        {
+            UUID buffer = (UUID) o;
             output.write('"');
             output.write(buffer.toString());
             output.write('"');

--- a/src/test/groovy/com/cedarsoftware/util/io/TestCollection.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestCollection.groovy
@@ -2,12 +2,10 @@ package com.cedarsoftware.util.io
 
 import org.junit.Test
 
-import java.awt.Point
+import java.awt.*
+import java.util.List
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertNotNull
-import static org.junit.Assert.assertNull
-import static org.junit.Assert.assertTrue
+import static org.junit.Assert.*
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -26,8 +24,7 @@ import static org.junit.Assert.assertTrue
  *         See the License for the specific language governing permissions and
  *         limitations under the License.
  */
-class TestCollection
-{
+class TestCollection {
     public static Date _testDate = new Date()
     public static Integer _CONST_INT = new Integer(36)
 
@@ -40,8 +37,7 @@ class TestCollection
         String foo = "bar"
     }
 
-    static class EmptyCols
-    {
+    static class EmptyCols {
         Collection col = new LinkedList()
         List list = new ArrayList()
         Map map = new HashMap()
@@ -50,23 +46,19 @@ class TestCollection
         SortedMap sortedMap = new TreeMap()
     }
 
-    static class ParameterizedCollection
-    {
+    static class ParameterizedCollection {
         Map<String, Set<Point>> content = new LinkedHashMap<String, Set<Point>>()
     }
 
-    static class PointList
-    {
+    static class PointList {
         List<Point> points;
     }
 
-    static class EmptyArrayList
-    {
+    static class EmptyArrayList {
         ArrayList<String> list = []
     }
 
-    private static class ManyCollections implements Serializable
-    {
+    private static class ManyCollections implements Serializable {
         private Collection[] _cols;
         private List _strings_a;
         private List _strings_b;
@@ -88,8 +80,7 @@ class TestCollection
         private Set _strs_d;
         private HashSet _typedSet;
 
-        private void init()
-        {
+        private void init() {
             Collection array = new ArrayList()
             array.add(_testDate)
             array.add("Hello")
@@ -103,9 +94,9 @@ class TestCollection
             set.add(_CONST_INT)
 
             Collection tree = new TreeSet()
-            tree.add(new Integer(Integer.MIN_VALUE))
-            tree.add(new Integer(1))
-            tree.add(new Integer(Integer.MAX_VALUE))
+            tree.add(Integer.valueOf(Integer.MIN_VALUE))
+            tree.add(Integer.valueOf(1))
+            tree.add(Integer.valueOf(Integer.MAX_VALUE))
             tree.add(_CONST_INT)
 
             _cols = [array, set, tree] as Collection[];
@@ -150,13 +141,13 @@ class TestCollection
 
             _poly_a = new ArrayList()
             _poly_a.add(Boolean.TRUE)
-            _poly_a.add(new Character('a' as char))
-            _poly_a.add(new Byte((byte) 16))
-            _poly_a.add(new Short((short) 69))
-            _poly_a.add(new Integer(714))
-            _poly_a.add(new Long(420))
-            _poly_a.add(new Float(0.4))
-            _poly_a.add(new Double(3.14))
+            _poly_a.add(Character.valueOf('a' as char))
+            _poly_a.add(Byte.valueOf((byte) 16))
+            _poly_a.add(Short.valueOf((short) 69))
+            _poly_a.add(Integer.valueOf(714))
+            _poly_a.add(Long.valueOf(420))
+            _poly_a.add(Float.valueOf(0.4))
+            _poly_a.add(Double.valueOf(3.14))
             _poly_a.add("Jones'in\tfor\u0019a\ncoke")
             _poly_a.add(null)
             _poly_a.add(new StringBuffer("eddie"))
@@ -204,8 +195,7 @@ class TestCollection
     }
 
     @Test
-    void testCollection()
-    {
+    void testCollection() {
         TestUtil.printLine("\nTestJsonReaderWriter.testCollection()")
         ManyCollections obj = new ManyCollections()
         obj.init()
@@ -222,8 +212,7 @@ class TestCollection
 //        System.out.TestUtil.printLine("writer._identity = " + writer._identity)
     }
 
-    private void assertCollection(ManyCollections root)
-    {
+    private void assertCollection(ManyCollections root) {
         assertTrue(root._cols.length == 3)
         assertTrue(root._cols[0].getClass().equals(ArrayList.class))
         assertTrue(root._cols[1].getClass().equals(HashSet.class))
@@ -249,9 +238,9 @@ class TestCollection
         set = root._cols[2];
         assertTrue(set.size() == 4)
         assertTrue(set.getClass().equals(TreeSet.class))
-        assertTrue(set.contains(new Integer(Integer.MIN_VALUE)))
-        assertTrue(set.contains(new Integer(1)))
-        assertTrue(set.contains(new Integer(Integer.MAX_VALUE)))
+        assertTrue(set.contains(Integer.valueOf(Integer.MIN_VALUE)))
+        assertTrue(set.contains(Integer.valueOf(1)))
+        assertTrue(set.contains(Integer.valueOf(Integer.MAX_VALUE)))
         assertTrue(set.contains(_CONST_INT))
 
         assertTrue(root._strings_a.size() == 4)
@@ -294,13 +283,13 @@ class TestCollection
 
         assertTrue(root._poly_a.size() == 17)
         assertTrue(root._poly_a.get(0).equals(Boolean.TRUE))
-        assertTrue(root._poly_a.get(1).equals(new Character('a' as char)))
-        assertTrue(root._poly_a.get(2).equals(new Byte((byte) 16)))
-        assertTrue(root._poly_a.get(3).equals(new Short((byte) 69)))
-        assertTrue(root._poly_a.get(4).equals(new Integer(714)))
-        assertTrue(root._poly_a.get(5).equals(new Long(420)))
-        assertTrue(root._poly_a.get(6).equals(new Float(0.4)))
-        assertTrue(root._poly_a.get(7).equals(new Double(3.14)))
+        assertTrue(root._poly_a.get(1).equals(Character.valueOf('a' as char)))
+        assertTrue(root._poly_a.get(2).equals(Byte.valueOf((byte) 16)))
+        assertTrue(root._poly_a.get(3).equals(Short.valueOf((byte) 69)))
+        assertTrue(root._poly_a.get(4).equals(Integer.valueOf(714)))
+        assertTrue(root._poly_a.get(5).equals(Long.valueOf(420)))
+        assertTrue(root._poly_a.get(6).equals(Float.valueOf(0.4)))
+        assertTrue(root._poly_a.get(7).equals(Double.valueOf(3.14)))
         assertTrue(root._poly_a.get(8).equals("Jones'in\tfor\u0019a\ncoke"))
         assertNull(root._poly_a.get(9))
         assertTrue(root._poly_a.get(10).toString().equals("eddie"))
@@ -339,16 +328,16 @@ class TestCollection
         assertTrue(root._strs_d instanceof TreeSet)
 
         assertTrue(root._typedCol != null)
-        assertTrue(root._typedCol .size() == 6)
+        assertTrue(root._typedCol.size() == 6)
         assertTrue("string".equals(root._typedCol.get(0)))
         assertTrue(null == root._typedCol.get(1))
         assertTrue((new Date(19)).equals(root._typedCol.get(2)))
-        assertTrue((Boolean)root._typedCol.get(3))
+        assertTrue((Boolean) root._typedCol.get(3))
         assertTrue(17.76 == (Double) root._typedCol.get(4))
         assertTrue(TimeZone.getTimeZone("PST").equals(root._typedCol.get(5)))
 
         assertTrue(root._typedSet != null)
-        assertTrue(root._typedSet .size() == 6)
+        assertTrue(root._typedSet.size() == 6)
         assertTrue(root._typedSet.contains("string"))
         assertTrue(root._typedCol.contains(null))
         assertTrue(root._typedCol.contains(new Date(19)))
@@ -358,13 +347,12 @@ class TestCollection
     }
 
     @Test
-    void testReconstituteCollection2()
-    {
+    void testReconstituteCollection2() {
         ManyCollections testCol = new ManyCollections()
         testCol.init()
         String json0 = TestUtil.getJsonString(testCol)
         TestUtil.printLine("json0=" + json0)
-        Map testCol2 = (Map) JsonReader.jsonToJava(json0, [(JsonReader.USE_MAPS):true] as Map)
+        Map testCol2 = (Map) JsonReader.jsonToJava(json0, [(JsonReader.USE_MAPS): true] as Map)
 
         String json1 = TestUtil.getJsonString(testCol2)
         TestUtil.printLine("json1=" + json1)
@@ -375,21 +363,19 @@ class TestCollection
     }
 
     @Test
-    void testAlwaysShowType()
-    {
-		ManyCollections tc = new ManyCollections()
-		tc.init()
-        def args = [(JsonWriter.TYPE):true]
+    void testAlwaysShowType() {
+        ManyCollections tc = new ManyCollections()
+        tc.init()
+        def args = [(JsonWriter.TYPE): true]
         def json0 = JsonWriter.objectToJson(tc, args)
-		def json1 = JsonWriter.objectToJson(tc)
-		TestUtil.printLine("json0 = " + json0)
-		TestUtil.printLine("json1 = " + json1)
-		assertTrue(json0.length() > json1.length())
+        def json1 = JsonWriter.objectToJson(tc)
+        TestUtil.printLine("json0 = " + json0)
+        TestUtil.printLine("json1 = " + json1)
+        assertTrue(json0.length() > json1.length())
     }
 
     @Test
-    void testCollectionWithEmptyElement()
-    {
+    void testCollectionWithEmptyElement() {
         List list = new ArrayList()
         list.add("a")
         list.add(null)
@@ -407,8 +393,7 @@ class TestCollection
     }
 
     @Test
-    void testCollectionWithReferences()
-    {
+    void testCollectionWithReferences() {
         TestObject o = new TestObject("JSON")
         List list = new ArrayList()
         list.add(o)
@@ -428,20 +413,18 @@ class TestCollection
     }
 
     @Test
-    void testCollectionWithNonJsonPrimitives()
-    {
+    void testCollectionWithNonJsonPrimitives() {
         Collection col = new ArrayList()
-        col.add(new Integer(7))
-        col.add(new Short((short) 9))
-        col.add(new Float(3.14))
+        col.add(Integer.valueOf(7))
+        col.add(Short.valueOf((short) 9))
+        col.add(Float.valueOf(3.14))
         String json = TestUtil.getJsonString(col)
         Collection col1 = (Collection) TestUtil.readJsonObject(json)
         assertTrue(col.equals(col1))
     }
 
     @Test
-    void testCollectionWithParameterizedTypes()
-    {
+    void testCollectionWithParameterizedTypes() {
         String json = '{"@type":"' + ParameterizedCollection.class.getName() + '", "content":{"foo":[{"x":1,"y":2},{"x":10,"y":20}],"bar":[{"x":3,"y":4}, {"x":30,"y":40}]}}'
         ParameterizedCollection pCol = (ParameterizedCollection) JsonReader.jsonToJava(json)
         Set<Point> points = pCol.content.get("foo")
@@ -476,8 +459,7 @@ class TestCollection
     }
 
     @Test
-    void testEmptyCollections()
-    {
+    void testEmptyCollections() {
         EmptyCols emptyCols;
         String className = TestCollection.class.getName()
         String json = '{"@type":"' + className + '$EmptyCols","col":{},"list":{},"map":{},"set":{},"sortedSet":{},"sortedMap":{}}'
@@ -499,8 +481,7 @@ class TestCollection
     }
 
     @Test
-    void testEnumWithPrivateMembersInCollection()
-    {
+    void testEnumWithPrivateMembersInCollection() {
         TestEnum4 x = TestEnum4.B;
         List list = new ArrayList()
         list.add(x)
@@ -510,7 +491,7 @@ class TestCollection
         assertEquals('{"@type":"java.util.ArrayList","@items":[{"@type":"' + className + '$TestEnum4","age":21,"foo":"bar","name":"B"}]}', json)
 
         ByteArrayOutputStream ba = new ByteArrayOutputStream()
-        JsonWriter writer = new JsonWriter(ba, [(JsonWriter.ENUM_PUBLIC_ONLY):true])
+        JsonWriter writer = new JsonWriter(ba, [(JsonWriter.ENUM_PUBLIC_ONLY): true])
         writer.write(list)
         json = new String(ba.toByteArray())
         TestUtil.printLine(json)
@@ -518,8 +499,7 @@ class TestCollection
     }
 
     @Test
-    void testGenericInfoCollection()
-    {
+    void testGenericInfoCollection() {
         String className = PointList.class.name
         String json = '{"@type":"' + className + '","points":{"@type":"java.util.ArrayList","@items":[{"x":1,"y":2}]}}'
         PointList list = (PointList) TestUtil.readJsonObject(json)
@@ -529,8 +509,7 @@ class TestCollection
     }
 
     @Test
-    void testLocaleInCollection()
-    {
+    void testLocaleInCollection() {
         Locale locale = new Locale(Locale.ENGLISH.getLanguage(), Locale.US.getCountry())
         List list = new ArrayList()
         list.add(locale)
@@ -542,8 +521,7 @@ class TestCollection
     }
 
     @Test
-    void testMapOfMapsCollection()
-    {
+    void testMapOfMapsCollection() {
         List stuff = new ArrayList()
         stuff.add("Hello")
         Object testObj = new TestObject("test object")
@@ -553,7 +531,7 @@ class TestCollection
         String json = TestUtil.getJsonString(stuff)
         TestUtil.printLine("json=" + json)
 
-        JsonObject map = JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
+        JsonObject map = JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS): true] as Map)
         Object[] items = map.getArray()
         assertTrue(items.length == 4)
         assertTrue("Hello".equals(items[0]))
@@ -563,7 +541,7 @@ class TestCollection
         list.add([123L, null, true, "Hello"] as Object[])
         json = TestUtil.getJsonString(list)
         TestUtil.printLine("json=" + json)
-        map = JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
+        map = JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS): true] as Map)
         items = (Object[]) map.getArray()
         assertTrue(items.length == 1)
         Object[] oa = (Object[]) items[0];
@@ -575,8 +553,7 @@ class TestCollection
     }
 
     @Test
-    void testReconstituteCollection()
-    {
+    void testReconstituteCollection() {
         TestObject to = new TestObject("football")
         Collection objs = new ArrayList()
         Date now = new Date()
@@ -585,7 +562,7 @@ class TestCollection
         objs.add("This is a string")
         objs.add(null)
         objs.add(to)
-        objs.add(["dog", ["a","b","c"] as String[]] as Object[])
+        objs.add(["dog", ["a", "b", "c"] as String[]] as Object[])
         Collection two = new ArrayList()
         two.add(objs)
         two.add("bella")
@@ -593,7 +570,7 @@ class TestCollection
 
         String json0 = TestUtil.getJsonString(two)
         TestUtil.printLine("json0=" + json0)
-        Map map = (Map) JsonReader.jsonToJava(json0, [(JsonReader.USE_MAPS):true] as Map)
+        Map map = (Map) JsonReader.jsonToJava(json0, [(JsonReader.USE_MAPS): true] as Map)
         map.hashCode()
         String json1 = TestUtil.getJsonString(map)
         TestUtil.printLine("json1=" + json1)
@@ -620,13 +597,12 @@ class TestCollection
     }
 
     @Test
-    void testReconstituteEmptyCollection()
-    {
+    void testReconstituteEmptyCollection() {
         Collection empty = new ArrayList()
         String json0 = TestUtil.getJsonString(empty)
         TestUtil.printLine("json0=" + json0)
 
-        Map map = (Map) JsonReader.jsonToJava(json0, [(JsonReader.USE_MAPS):true] as Map)
+        Map map = (Map) JsonReader.jsonToJava(json0, [(JsonReader.USE_MAPS): true] as Map)
         assertTrue(map != null)
         assertTrue(map.isEmpty())
         String json1 = TestUtil.getJsonString(map)
@@ -638,7 +614,7 @@ class TestCollection
         json0 = TestUtil.getJsonString(list)
         TestUtil.printLine("json0=" + json0)
 
-        Object[] array = (Object[]) JsonReader.jsonToJava(json0, [(JsonReader.USE_MAPS):true] as Map)
+        Object[] array = (Object[]) JsonReader.jsonToJava(json0, [(JsonReader.USE_MAPS): true] as Map)
         assertTrue(array != null)
         list = array
         assertTrue(list.length == 2)
@@ -649,34 +625,32 @@ class TestCollection
     }
 
     @Test
-    void testUntypedCollections()
-    {
+    void testUntypedCollections() {
         Object[] poly = ["Road Runner", 16L, 3.1415d, true, false, null, 7, "Coyote", "Coyote"] as Object[];
         String json = TestUtil.getJsonString(poly)
         TestUtil.printLine("json=" + json)
         assertTrue('["Road Runner",16,3.1415,true,false,null,{"@type":"int","value":7},"Coyote","Coyote"]'.equals(json))
         Collection col = new ArrayList()
         col.add("string")
-        col.add(new Long(16))
-        col.add(new Double(3.14159))
+        col.add(Long.valueOf(16))
+        col.add(Double.valueOf(3.14159))
         col.add(Boolean.TRUE)
         col.add(Boolean.FALSE)
         col.add(null)
-        col.add(new Integer(7))
+        col.add(Integer.valueOf(7))
         json = TestUtil.getJsonString(col)
         TestUtil.printLine("json=" + json)
         assertEquals('{"@type":"java.util.ArrayList","@items":["string",16,3.14159,true,false,null,{"@type":"int","value":7}]}', json)
     }
 
     @Test
-    void testEmptyArrayList()
-    {
+    void testEmptyArrayList() {
         EmptyArrayList x = new EmptyArrayList()
         String json = TestUtil.getJsonString(x)
         TestUtil.printLine(json)
         assertTrue(json.contains('list":[]'))
 
-        Map obj = JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
+        Map obj = JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS): true] as Map)
         json = TestUtil.getJsonString(obj)
         TestUtil.printLine(json)
         assertTrue(json.contains('list":[]'))

--- a/src/test/groovy/com/cedarsoftware/util/io/TestNoType.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestNoType.groovy
@@ -43,9 +43,9 @@ class TestNoType
         cal.set(-700, 5, 10)
 
         Junk j = new Junk()
-        j.stuff = [(int)1, 2L, new BigInteger(3), new BigDecimal(4.0), cal.getTime(), 'Hello', Junk.class] as Object[]
+        j.stuff = [(int)1, 2L, BigInteger.valueOf(3), new BigDecimal(4.0), cal.getTime(), 'Hello', Junk.class] as Object[]
         j.name = 'Zeus'
-        j.things = [(int)1, 2L, new BigInteger(3), new BigDecimal(4.0), cal.getTime(), 'Hello', Junk.class] as Object[]
+        j.things = [(int)1, 2L, BigInteger.valueOf(3), new BigDecimal(4.0), cal.getTime(), 'Hello', Junk.class] as Object[]
         j.namesToAge.Appollo = 2500L
         j.namesToAge.Hercules = 2489 as int
         j.namesToAge.Poseidon = 2502 as BigInteger

--- a/src/test/groovy/com/cedarsoftware/util/io/TestUUID.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestUUID.groovy
@@ -49,7 +49,7 @@ class TestUUID {
         assertEquals(IllegalArgumentException.class, thrown.cause.class)
 
         json = '{"@type":"' + TestUUIDFields.class.name + '", "internals": {"@type": "java.util.UUID", "leastSigBits":-7929886640328317609}}'
-         thrown = Assert.assertThrows(JsonIoException.class, { (TestUUIDFields) TestUtil.readJsonObject(json) })
+        thrown = Assert.assertThrows(JsonIoException.class, { (TestUUIDFields) TestUtil.readJsonObject(json) })
         assertTrue("", thrown.cause.message.contains("mostSigBits"))
 
         json = '{"@type":"' + TestUUIDFields.class.name + '", "internals": {"@type": "java.util.UUID", "mostSigBits":7280309849777586861}}'
@@ -66,7 +66,7 @@ class TestUUID {
         String json = TestUtil.getJsonString(uuid)
         TestUtil.printLine("json=" + json)
         uuid = (UUID) TestUtil.readJsonObject(json)
-        assertTrue(uuid.equals(UUID.fromString(s)))
+        assertEquals(UUID.fromString(s), uuid)
     }
 
     @Test
@@ -86,21 +86,21 @@ class TestUUID {
         TestUtil.printLine("json=" + json)
         assertTrue(typedUUIDs.length == 2)
         assertTrue(typedUUIDs[0] == typedUUIDs[1])
-        assertTrue(UUID.fromString(s).equals(typedUUIDs[0]))
+        assertEquals(UUID.fromString(s), typedUUIDs[0])
     }
 
     @Test
     void testUUIDInCollection() {
         String s = "03a7e3c2-2d3a-4ca9-a426-ff4270015fde"
-        UUID bigDec = UUID.fromString(s)
+        UUID uuid = UUID.fromString(s)
         List list = new ArrayList()
-        list.add(bigDec)
-        list.add(bigDec)
+        list.add(uuid)
+        list.add(uuid)
         String json = TestUtil.getJsonString(list)
         TestUtil.printLine("json=" + json)
         list = (List) TestUtil.readJsonObject(json)
         assertTrue(list.size() == 2)
-        assertTrue(list.get(0).equals(UUID.fromString(s)))
+        assertEquals(UUID.fromString(s), list.get(0))
         assertSame(list.get(0), list.get(1))
     }
 }

--- a/src/test/groovy/com/cedarsoftware/util/io/TestUUID.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestUUID.groovy
@@ -1,0 +1,106 @@
+package com.cedarsoftware.util.io
+
+import groovy.transform.CompileStatic
+import org.junit.Assert
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+/**
+ * @author Balazs Bessenyei (h143570@gmail.com)
+ *         <br><br>
+ *         Licensed under the Apache License, Version 2.0 (the "License")
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *         <br><br>
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *         <br><br>
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ */
+@CompileStatic
+class TestUUID {
+    static class TestUUIDFields {
+        UUID fromString
+        UUID internals
+        UUID internalsObj
+    }
+
+    @Test
+    void testAssignUUID() {
+        String json = '{"@type":"' + TestUUIDFields.class.name + '","fromString":"6508db3c-52c5-42ad-91f3-621d6e1d6557", "internals": {"@type": "java.util.UUID", "mostSigBits":7280309849777586861,"leastSigBits":-7929886640328317609}}'
+        TestUUIDFields tu = (TestUUIDFields) TestUtil.readJsonObject(json)
+        assertEquals((Object) UUID.fromString("6508db3c-52c5-42ad-91f3-621d6e1d6557"), tu.fromString)
+        assertEquals((Object) UUID.fromString("6508db3c-52c5-42ad-91f3-621d6e1d6557"), tu.internals)
+
+
+        Map map = (Map) JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS): true] as Map)
+        json = TestUtil.getJsonString(map)
+        tu = (TestUUIDFields) TestUtil.readJsonObject(json)
+        assertEquals((Object) UUID.fromString("6508db3c-52c5-42ad-91f3-621d6e1d6557"), tu.fromString)
+        assertEquals((Object) UUID.fromString("6508db3c-52c5-42ad-91f3-621d6e1d6557"), tu.internals)
+
+
+        json = '{"@type":"' + TestUUIDFields.class.name + '","fromString":""}'
+        Throwable thrown = Assert.assertThrows(JsonIoException.class, { (TestUUIDFields) TestUtil.readJsonObject(json) })
+        assertEquals(IllegalArgumentException.class, thrown.cause.class)
+
+        json = '{"@type":"' + TestUUIDFields.class.name + '", "internals": {"@type": "java.util.UUID", "leastSigBits":-7929886640328317609}}'
+         thrown = Assert.assertThrows(JsonIoException.class, { (TestUUIDFields) TestUtil.readJsonObject(json) })
+        assertTrue("", thrown.cause.message.contains("mostSigBits"))
+
+        json = '{"@type":"' + TestUUIDFields.class.name + '", "internals": {"@type": "java.util.UUID", "mostSigBits":7280309849777586861}}'
+        thrown = Assert.assertThrows(JsonIoException.class, { (TestUUIDFields) TestUtil.readJsonObject(json) })
+        assertTrue("", thrown.cause.message.contains("leastSigBits"))
+    }
+
+
+    @Test
+    void testUUID() {
+
+        String s = "9bf37453-c576-432b-a531-2dbc2be797c2"
+        UUID uuid = UUID.fromString(s)
+        String json = TestUtil.getJsonString(uuid)
+        TestUtil.printLine("json=" + json)
+        uuid = (UUID) TestUtil.readJsonObject(json)
+        assertTrue(uuid.equals(UUID.fromString(s)))
+    }
+
+    @Test
+    void testUUIDInArray() {
+        String s = "f3060936-aae9-4273-aead-2768d99cf9e7"
+        UUID uuid = UUID.fromString(s)
+        Object[] uuids = [uuid, uuid] as Object[]
+        UUID[] typedUUIDs = [uuid, uuid] as UUID[]
+        String json = TestUtil.getJsonString(uuids)
+        TestUtil.printLine("json=" + json)
+
+        uuids = (Object[]) TestUtil.readJsonObject(json)
+        assertTrue(uuids.length == 2)
+        assertSame(uuids[0], uuids[1])
+        assertTrue(UUID.fromString(s).equals(uuids[0]))
+        json = TestUtil.getJsonString(typedUUIDs)
+        TestUtil.printLine("json=" + json)
+        assertTrue(typedUUIDs.length == 2)
+        assertTrue(typedUUIDs[0] == typedUUIDs[1])
+        assertTrue(UUID.fromString(s).equals(typedUUIDs[0]))
+    }
+
+    @Test
+    void testUUIDInCollection() {
+        String s = "03a7e3c2-2d3a-4ca9-a426-ff4270015fde"
+        UUID bigDec = UUID.fromString(s)
+        List list = new ArrayList()
+        list.add(bigDec)
+        list.add(bigDec)
+        String json = TestUtil.getJsonString(list)
+        TestUtil.printLine("json=" + json)
+        list = (List) TestUtil.readJsonObject(json)
+        assertTrue(list.size() == 2)
+        assertTrue(list.get(0).equals(UUID.fromString(s)))
+        assertSame(list.get(0), list.get(1))
+    }
+}

--- a/src/test/groovy/com/cedarsoftware/util/io/TestWriters.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestWriters.groovy
@@ -46,8 +46,8 @@ class TestWriters
     @Test
     void testNumericTruth()
     {
-        assertFalse JsonWriter.isTrue(new BigInteger(0))
-        assertTrue JsonWriter.isTrue(new BigInteger(1))
+        assertFalse JsonWriter.isTrue(BigInteger.valueOf(0))
+        assertTrue JsonWriter.isTrue(BigInteger.valueOf(1))
         assertFalse JsonWriter.isTrue(new BigDecimal(0.0))
         assertTrue JsonWriter.isTrue(new BigDecimal(1.1))
         assertFalse JsonWriter.isTrue(0.0d)


### PR DESCRIPTION
- Created custom JsonReader and JsonWritter for UUID
- The generated format is compatible with previous versions
- Created a primitive version that uses `fromString` to create the UUID, this may cause issues during rolling updates or if older version tries to read the new format. We can remove the capability if full backward and forward compatibility is desired
- updated dependencies to latest