### PR TITLE
Fixed TestJavaScript

### DIFF
--- a/src/test/groovy/com/cedarsoftware/util/io/TestJavascript.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestJavascript.groovy
@@ -1,8 +1,11 @@
 package com.cedarsoftware.util.io
+
+
 import org.junit.Test
 
 import javax.script.ScriptEngine
 import javax.script.ScriptEngineManager
+
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
  *         <br>
@@ -20,13 +23,13 @@ import javax.script.ScriptEngineManager
  *         See the License for the specific language governing permissions and
  *         limitations under the License.
  */
-class TestJavascript
-{
+class TestJavascript {
+    private static final ScriptEngineManager scm = new ScriptEngineManager(ClassLoader.getSystemClassLoader());
+
     @Test
-    void testJsonUtilRefInsideArray()
-    {
-        ScriptEngineManager factory = new ScriptEngineManager()
-        ScriptEngine engine = factory.getEngineByName("JavaScript")
+    void testJsonUtilRefInsideArray() {
+
+        ScriptEngine engine = scm.getEngineByName("JavaScript")
 
         String jsonUtil = TestUtil.fetchResource('jsonUtil.js')
         engine.eval(jsonUtil)
@@ -45,10 +48,8 @@ assert(array[0] === array[1]);   // Exactly the same instance
     }
 
     @Test
-    void testJsonUtilForwardRefInsideArray()
-    {
-        ScriptEngineManager factory = new ScriptEngineManager()
-        ScriptEngine engine = factory.getEngineByName("JavaScript")
+    void testJsonUtilForwardRefInsideArray() {
+        ScriptEngine engine = scm.getEngineByName("JavaScript")
 
         String jsonUtil = TestUtil.fetchResource('jsonUtil.js')
         engine.eval(jsonUtil)
@@ -67,10 +68,8 @@ assert(array[0] === array[1]);   // Exactly the same instance
     }
 
     @Test
-    void testJsonUtilRefInsideObject()
-    {
-        ScriptEngineManager factory = new ScriptEngineManager()
-        ScriptEngine engine = factory.getEngineByName("JavaScript")
+    void testJsonUtilRefInsideObject() {
+        ScriptEngine engine = scm.getEngineByName("JavaScript")
 
         String jsonUtil = TestUtil.fetchResource('jsonUtil.js')
         engine.eval(jsonUtil)
@@ -92,10 +91,8 @@ assert(!testObj._other._other['@ref']);
     }
 
     @Test
-    void testJsonUtilRefCycle()
-    {
-        ScriptEngineManager factory = new ScriptEngineManager()
-        ScriptEngine engine = factory.getEngineByName("JavaScript")
+    void testJsonUtilRefCycle() {
+        ScriptEngine engine = scm.getEngineByName("JavaScript")
 
         String jsonUtil = TestUtil.fetchResource('jsonUtil.js')
         engine.eval(jsonUtil)


### PR DESCRIPTION
ScriptEngineManager uses the thread context classloader, due to the library version updates this test could no longer see the System Classloader which has the JavaScript engine registered.