### PR TITLE
Fix #169

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.2.1</version>
+                <version>5.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>

--- a/src/test/groovy/com/cedarsoftware/util/io/TestOverflow.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestOverflow.groovy
@@ -1,0 +1,37 @@
+package com.cedarsoftware.util.io
+
+import org.junit.Test
+
+import static org.junit.Assert.assertThrows
+import static org.junit.Assert.assertTrue
+
+class TestOverflow
+{
+    private final static int TOO_DEEP_NESTING = 9999;
+    private final static String TOO_DEEP_DOC = nestedDoc(TOO_DEEP_NESTING, "[ ", "] ", "0");
+
+    private static String nestedDoc(int nesting, String open, String close, String content) {
+        StringBuilder sb = new StringBuilder(nesting * (open.length() + close.length()));
+        for (int i = 0; i < nesting; ++i) {
+            sb.append(open);
+            if ((i & 31) == 0) {
+                sb.append("\n");
+            }
+        }
+        sb.append("\n").append(content).append("\n");
+        for (int i = 0; i < nesting; ++i) {
+            sb.append(close);
+            if ((i & 31) == 0) {
+                sb.append("\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    @Test
+    void testOverflow()
+    {
+        Throwable thrown = assertThrows(JsonIoException.class, { JsonReader.jsonToJava(TOO_DEEP_DOC) })
+        assertTrue("", thrown.message.contains("Maximum parsing depth exceeded"))
+    }
+}


### PR DESCRIPTION
This PR fixes a potential stack overflow being thrown when parsing untrusted input. The APIs now accept a customizable amount of maximum parsing depth, with a safe default that should allow parsing most sane inputs without causing overflow issues.

This PR closes issue #169 