### PR TITLE
More frugal enumset

### DIFF
--- a/src/main/java/com/cedarsoftware/util/io/JsonWriter.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonWriter.java
@@ -2237,7 +2237,7 @@ public class JsonWriter implements Closeable, Flushable
         Class elementType = (Class) getValueByReflect(enumSet, elementTypeField);
         writeJsonUtf8String(elementType.getName(), out);
 
-        var mapOfFileds = MetaUtils.getDeepDeclaredFields(elementType);
+        Map<String, Field> mapOfFileds = MetaUtils.getDeepDeclaredFields(elementType);
         //Field[] enumFields = elementType.getDeclaredFields();
         int enumFieldsCount = mapOfFileds.size();
 
@@ -2253,7 +2253,7 @@ public class JsonWriter implements Closeable, Flushable
             }
 
             boolean firstInSet = true;
-            for (var e : enumSet) {
+            for (Enum e : enumSet) {
                 if (!firstInSet)
                 {
                     out.write(",");
@@ -2272,7 +2272,7 @@ public class JsonWriter implements Closeable, Flushable
                 {
                     boolean firstInEntry = true;
                     out.write('{');
-                    for (var f : mapOfFileds.values())
+                    for (Field f : mapOfFileds.values())
                     {
                         firstInEntry = writeField(e, firstInEntry, f.getName(), f, false);
                     }

--- a/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
+++ b/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
@@ -36,6 +36,8 @@ import static java.lang.reflect.Modifier.*;
  */
 public class MetaUtils
 {
+    public enum Dumpty {}
+
     private MetaUtils () {}
     private static final Map<Class, Map<String, Field>> classMetaCache = new ConcurrentHashMap<>();
     private static final Set<Class> prims = new HashSet<>();

--- a/src/main/java/com/cedarsoftware/util/io/ObjectResolver.java
+++ b/src/main/java/com/cedarsoftware/util/io/ObjectResolver.java
@@ -414,6 +414,13 @@ public class ObjectResolver extends Resolver
                 }
             return;
         }
+
+        Class mayEnumClass = null;
+        String mayEnumClasName = (String)jsonObj.get("@enum");
+        if (mayEnumClasName != null) {
+            mayEnumClass = MetaUtils.classForName(mayEnumClasName, classLoader);
+        }
+
         final boolean isImmutable = className != null && className.startsWith("java.util.Immutable");
         final Collection col = isImmutable ? new ArrayList() : (Collection) jsonObj.target;
         final boolean isList = col instanceof List;
@@ -436,7 +443,10 @@ public class ObjectResolver extends Resolver
             }
             else if (element instanceof String || element instanceof Boolean || element instanceof Double || element instanceof Long)
             {    // Allow Strings, Booleans, Longs, and Doubles to be "inline" without Java object decoration (@id, @type, etc.)
-                col.add(element);
+                if (mayEnumClass == null)
+                    col.add(element);
+                else
+                    col.add(Enum.valueOf(mayEnumClass, (String)element));
             }
             else if (element.getClass().isArray())
             {

--- a/src/test/java/com/cedarsoftware/util/io/TestEmptyEnumSetOnJDK17.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestEmptyEnumSetOnJDK17.java
@@ -1,12 +1,9 @@
 package com.cedarsoftware.util.io;
 
-import com.google.gson.Gson;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -29,7 +26,29 @@ public class TestEmptyEnumSetOnJDK17
 {
     static enum TestEnum
     {
-        V1
+        V1, V2, V3
+    }
+
+    static class MultiVersioned
+    {
+        EnumSet<TestEnum> versions;
+        String dummy;
+
+        public MultiVersioned(EnumSet<TestEnum> versions, String dummy) {
+            this.versions = versions;
+            this.dummy = dummy;
+        }
+
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            MultiVersioned that = (MultiVersioned) o;
+            return Objects.equals(versions, that.versions) && Objects.equals(dummy, that.dummy);
+        }
+
+        public int hashCode() {
+            return Objects.hash(versions, dummy);
+        }
     }
 
     @Test
@@ -46,11 +65,22 @@ public class TestEmptyEnumSetOnJDK17
     @Test
     public void testEnumSetOnJDK17()
     {
-        EnumSet source = EnumSet.of(TestEnum.V1);
+        EnumSet source = EnumSet.of(TestEnum.V1, TestEnum.V3);
 
         String json = JsonWriter.objectToJson(source);
         EnumSet target = (EnumSet) JsonReader.jsonToJava(json);
 
         assert source.equals(target);
+    }
+    @Test
+
+    public void testEnumSetInPoJoOnJDK17()
+    {
+        MultiVersioned m = new MultiVersioned(EnumSet.of(TestEnum.V1, TestEnum.V3), "what");
+
+        String json = JsonWriter.objectToJson(m);
+        MultiVersioned target = (MultiVersioned) JsonReader.jsonToJava(json);
+
+        assert m.equals(target);
     }
 }

--- a/src/test/java/com/cedarsoftware/util/io/TestEmptyEnumSetOnJDK17.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestEmptyEnumSetOnJDK17.java
@@ -33,10 +33,12 @@ public class TestEmptyEnumSetOnJDK17
     {
         EnumSet<TestEnum> versions;
         String dummy;
+        EnumSet<Thread.State> states;
 
-        public MultiVersioned(EnumSet<TestEnum> versions, String dummy) {
+        public MultiVersioned(EnumSet<TestEnum> versions, String dummy, EnumSet<Thread.State> states) {
             this.versions = versions;
             this.dummy = dummy;
+            this.states = states;
         }
 
         public boolean equals(Object o) {
@@ -76,7 +78,7 @@ public class TestEmptyEnumSetOnJDK17
 
     public void testEnumSetInPoJoOnJDK17()
     {
-        MultiVersioned m = new MultiVersioned(EnumSet.of(TestEnum.V1, TestEnum.V3), "what");
+        MultiVersioned m = new MultiVersioned(EnumSet.of(TestEnum.V1, TestEnum.V3), "what", EnumSet.of(Thread.State.NEW));
 
         String json = JsonWriter.objectToJson(m);
         MultiVersioned target = (MultiVersioned) JsonReader.jsonToJava(json);

--- a/src/test/java/com/cedarsoftware/util/io/TestJDK9Immutable.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestJDK9Immutable.java
@@ -27,7 +27,7 @@ public class TestJDK9Immutable {
         final Object o = new ArrayList<>(List.of());
 
         String json = JsonWriter.objectToJson(o);
-        List es = (List) JsonReader.jsonToJava(json);
+        List<?> es = (List<?>) JsonReader.jsonToJava(json);
 
         Assert.assertEquals(0, es.size());
         Assert.assertEquals(o.getClass(), es.getClass());
@@ -38,7 +38,7 @@ public class TestJDK9Immutable {
         final Object o = List.of();
 
         String json = JsonWriter.objectToJson(o);
-        List es = (List) JsonReader.jsonToJava(json);
+        List<?> es = (List<?>) JsonReader.jsonToJava(json);
 
         Assert.assertEquals(0, es.size());
         Assert.assertEquals(o.getClass(), es.getClass());
@@ -49,7 +49,7 @@ public class TestJDK9Immutable {
         final Object o = List.of("One");
 
         String json = JsonWriter.objectToJson(o);
-        List es = (List) JsonReader.jsonToJava(json);
+        List<?> es = (List<?>) JsonReader.jsonToJava(json);
 
         Assert.assertEquals(1, es.size());
         Assert.assertEquals(o.getClass(), es.getClass());
@@ -60,7 +60,7 @@ public class TestJDK9Immutable {
         final Object o = List.of("One", "Two");
 
         String json = JsonWriter.objectToJson(o);
-        List es = (List) JsonReader.jsonToJava(json);
+        List<?> es = (List<?>) JsonReader.jsonToJava(json);
 
         Assert.assertEquals(2, es.size());
         Assert.assertEquals(o.getClass(), es.getClass());
@@ -71,7 +71,7 @@ public class TestJDK9Immutable {
         final Object o = List.of("One", "Two", "Three");
 
         String json = JsonWriter.objectToJson(o);
-        List es = (List) JsonReader.jsonToJava(json);
+        List<?> es = (List<?>) JsonReader.jsonToJava(json);
 
         Assert.assertEquals(3, es.size());
         Assert.assertEquals(o.getClass(), es.getClass());
@@ -82,7 +82,7 @@ public class TestJDK9Immutable {
         final Object o = Set.of();
 
         String json = JsonWriter.objectToJson(o);
-        Set es = (Set) JsonReader.jsonToJava(json);
+        Set<?> es = (Set<?>) JsonReader.jsonToJava(json);
 
         Assert.assertEquals(0, es.size());
         Assert.assertEquals(o.getClass(), es.getClass());
@@ -93,7 +93,7 @@ public class TestJDK9Immutable {
         final Object o = Set.of("One");
 
         String json = JsonWriter.objectToJson(o);
-        Set es = (Set) JsonReader.jsonToJava(json);
+        Set<?> es = (Set<?>) JsonReader.jsonToJava(json);
 
         Assert.assertEquals(1, es.size());
         Assert.assertEquals(o.getClass(), es.getClass());
@@ -104,7 +104,7 @@ public class TestJDK9Immutable {
         final Object o = Set.of("One", "Two");
 
         String json = JsonWriter.objectToJson(o);
-        Set es = (Set) JsonReader.jsonToJava(json);
+        Set<?> es = (Set<?>) JsonReader.jsonToJava(json);
 
         Assert.assertEquals(2, es.size());
         Assert.assertEquals(o.getClass(), es.getClass());
@@ -115,7 +115,7 @@ public class TestJDK9Immutable {
         final Object o = Set.of("One", "Two", "Three");
 
         String json = JsonWriter.objectToJson(o);
-        Set es = (Set) JsonReader.jsonToJava(json);
+        Set<?> es = (Set<?>) JsonReader.jsonToJava(json);
 
         Assert.assertEquals(3, es.size());
         Assert.assertEquals(o.getClass(), es.getClass());
@@ -129,7 +129,6 @@ public class TestJDK9Immutable {
         rec2.link = rec1;
         rec1.mlinks = new ArrayList<>(List.of());
         rec2.mlinks = new ArrayList<>(List.of(rec1));
-        //List<Rec> ol = new ArrayList<>(List.of(rec1, rec2, rec1));
         List<Rec> ol = new ArrayList<>(List.of(rec1, rec2, rec1));
 
         String json = JsonWriter.objectToJson(ol);
@@ -161,7 +160,6 @@ public class TestJDK9Immutable {
         rec2.link = rec1;
         rec1.mlinks = new ArrayList<>(List.of());
         rec2.mlinks = new ArrayList<>(List.of(rec1));
-        //List<Rec> ol = new ArrayList<>(List.of(rec1, rec2, rec1));
         List<Rec> ol = List.of(rec1, rec2, rec1);
 
         String json = JsonWriter.objectToJson(ol);
@@ -198,11 +196,11 @@ public class TestJDK9Immutable {
         List<Rec> ol = List.of(rec1, rec2, rec1);
 
         String json = JsonWriter.objectToJson(ol);
-        List es = (List) JsonReader.jsonToJava(json);
+        Object es = (List) JsonReader.jsonToJava(json);
 
         Assert.assertEquals(((Object) ol).getClass(), es.getClass());
 
-        List<Rec> recs = es;
+        List<Rec> recs = (List<Rec>) es;
         Assert.assertEquals(ol.size(), recs.size());
 
         Assert.assertEquals(ol.get(0).s, recs.get(0).s);
@@ -229,26 +227,22 @@ public class TestJDK9Immutable {
     public void testListOfThreeRecsImmutableOnly() {
         Rec rec1 = new Rec("OneOrThree", 0);
         Rec rec2 = new Rec("Two", 2);
-        //rec1.link = rec2;
-        //rec2.link = rec1;
         rec1.ilinks = List.of(rec2, rec1);
         rec2.ilinks = List.of();
         List<Rec> ol = List.of(rec1, rec2, rec1);
 
         String json = JsonWriter.objectToJson(ol);
-        List es = (List) JsonReader.jsonToJava(json);
+        Object es = JsonReader.jsonToJava(json);
 
         Assert.assertEquals(((Object) ol).getClass(), es.getClass());
 
-        List<Rec> recs = es;
+        List<Rec> recs = (List<Rec>) es;
         Assert.assertEquals(ol.size(), recs.size());
 
         Assert.assertEquals(ol.get(0).s, recs.get(0).s);
         Assert.assertEquals(ol.get(0).i, recs.get(0).i);
-        //Assert.assertEquals(recs.get(1), recs.get(0).link);
         Assert.assertEquals(ol.get(1).s, recs.get(1).s);
         Assert.assertEquals(ol.get(1).i, recs.get(1).i);
-        //Assert.assertEquals(recs.get(0), recs.get(1).link);
 
         Assert.assertEquals(recs.get(0), recs.get(2));
 


### PR DESCRIPTION
In stead of
{"@type":"java.util.RegularEnumSet","@items":[{"@type":"com.cedarsoftware.util.io.TestEmptyEnumSetOnJDK17$TestEnum","name":"V1"},{"@type":"com.cedarsoftware.util.io.TestEmptyEnumSetOnJDK17$TestEnum","name":"V2"}]}
serialize to
{"@enum":"com.cedarsoftware.util.io.TestEmptyEnumSetOnJDK17$TestEnum","@items":["V1","V2"]}
not repeating the enum class nor the enumset implementation that is a consequence of the number of entries of the enum.