### PR TITLE
get back to jdk 1.8 as target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
                 <version>3.8.1</version>
                 <configuration>
                     <source>11</source>
-                    <target>11</target>
+                    <target>1.8</target>
                     <!--                    <release>1.8</release>-->
                     <compilerId>groovy-eclipse-compiler</compilerId>
                     <!-- <verbose>true</verbose> -->


### PR DESCRIPTION
jdk9_immutable branch merging gave away targetting jdk 1.8,
though mvn package and test would succeed with it.

So this merge request re-establishes jdk 1.8 as target,
keeping jdk 11 as bottom source, in contrast.