### PR TITLE
bugfix: records with non-public constructor and non-long primtive member

### DIFF
--- a/src/main/java/com/cedarsoftware/util/io/Readers.java
+++ b/src/main/java/com/cedarsoftware/util/io/Readers.java
@@ -881,11 +881,19 @@ public class Readers
                     Class<?> type = (Class<?>) recordComponent.getClass().getMethod("getType").invoke(recordComponent);
                     lParameterTypes.add(type);
 
-                    String name = (String) recordComponent.getClass().getMethod("getName").invoke(recordComponent);
-                    lParameterValues.add(jsonObj.get(name));
+                    String parameterName = (String) recordComponent.getClass().getMethod("getName").invoke(recordComponent);
+                    JsonObject parameterValueJsonObj = new JsonObject();
+                    parameterValueJsonObj.setType(type.getName());
+                    parameterValueJsonObj.put("value", jsonObj.get(parameterName));
+
+                    if(parameterValueJsonObj.isLogicalPrimitive())
+                        lParameterValues.add(parameterValueJsonObj.getPrimitiveValue());
+                    else
+                        lParameterValues.add(parameterValueJsonObj.get("value"));
                 }
 
                 Constructor constructor = c.getDeclaredConstructor(lParameterTypes.toArray(new Class[0]));
+                constructor.setAccessible(true);
 
                 return constructor.newInstance(lParameterValues.toArray(new Object[0]));
 


### PR DESCRIPTION
I appreciate that you merged my pull request to support records in json-io and that it is available in the current version '4.14.1', also in Maven central.

I tried it and ran into two issues:
1. A non-public record was not deserialized because the constructor was not public in this case.
   Fixed it by setting the constructor accessible.
3. I had a record with a member of the primitive type 'int'. The value inside the JsonObject for the record of this member, accessible with jsonObject.get(memberName), is of type Long. Thus I've received a "IllegalArgumentException: argument type mismatch".
  I have fixed it by creating a JsonObject instance for it, specifying the target type. JsonObject then can check whether it is a primitive type and returns the right value if necessary.
