### PR TITLE
Fix map of crash

### DIFF
--- a/src/main/java/com/cedarsoftware/util/io/Resolver.java
+++ b/src/main/java/com/cedarsoftware/util/io/Resolver.java
@@ -403,6 +403,10 @@ abstract class Resolver
                 {
                     mate = new ArrayList<>();
                 }
+                else if (c.getName().contains("Map"))
+                {
+                    mate = new LinkedHashMap<>();
+                }
             }
         }
         else

--- a/src/test/java/com/cedarsoftware/util/io/TestJDK9Immutable.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestJDK9Immutable.java
@@ -2,6 +2,7 @@ package com.cedarsoftware.util.io;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.Assert;
@@ -20,6 +21,8 @@ public class TestJDK9Immutable {
         Rec       link;
         List<Rec> ilinks;
         List<Rec> mlinks;
+
+		Map<String, Rec> smap;
     }
 
     @Test
@@ -234,6 +237,8 @@ public class TestJDK9Immutable {
         rec1.ilinks = List.of(rec2, rec1);
         rec2.ilinks = List.of();
         List<Rec> ol = List.of(rec1, rec2, rec1);
+
+		rec1.smap = Map.of();
 
         String json = JsonWriter.objectToJson(ol);
         List es = (List) JsonReader.jsonToJava(json);


### PR DESCRIPTION
My additions for handling List.of and Set.of have weaken the deserialization as a Map.of would provoke a NPE