### PR TITLE
* Changed Target compilation to 9 since some items were 9 specific (S…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
     <properties>
         <maven.compiler.fork>true</maven.compiler.fork>
         <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.target>9</maven.compiler.target>
+        <maven.compiler.release>9</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!--
             Name of the benchmark Uber-JAR to generate.
@@ -154,12 +154,12 @@
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
-                    <!--                    <release>1.8</release>-->
+                    <release>${maven.compiler.release}</release>
+                    <fork>${maven.compiler.fork}</fork>
                     <compilerId>groovy-eclipse-compiler</compilerId>
                     <compilerArguments>
                         <indy/>
                     </compilerArguments>
-                    <!-- <verbose>true</verbose> -->
                 </configuration>
                 <dependencies>
                     <dependency>
@@ -271,12 +271,17 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.cedarsoftware</groupId>
             <artifactId>java-util</artifactId>
@@ -284,18 +289,17 @@
             <scope>test</scope>
             <optional>true</optional>
         </dependency>
-
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.9.1</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
             <version>4.0.15</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -311,5 +315,12 @@
             <version>1.35</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.24.2</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/src/main/java/com/cedarsoftware/util/io/ArgumentHelper.java
+++ b/src/main/java/com/cedarsoftware/util/io/ArgumentHelper.java
@@ -1,0 +1,28 @@
+package com.cedarsoftware.util.io;
+
+public class ArgumentHelper {
+    /**
+     * @param setting Object setting value from JsonWriter args map.
+     * @return boolean true if the value is (boolean) true, Boolean.TRUE, "true" (any case), or non-zero if a Number.
+     */
+    public static boolean isTrue(Object setting)
+    {
+        if (setting instanceof Boolean)
+        {
+            return Boolean.TRUE.equals(setting);
+        }
+
+        if (setting instanceof String)
+        {
+            return "true".equalsIgnoreCase((String) setting);
+        }
+
+        if (setting instanceof Number)
+        {
+            return ((Number)setting).intValue() != 0;
+        }
+
+        return false;
+    }
+
+}

--- a/src/main/java/com/cedarsoftware/util/io/JsonReader.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonReader.java
@@ -3,6 +3,7 @@ package com.cedarsoftware.util.io;
 import java.io.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.util.*;
@@ -141,6 +142,10 @@ public class JsonReader implements Closeable
         temp.put(StringBuilder.class, new Readers.StringBuilderReader());
         temp.put(StringBuffer.class, new Readers.StringBufferReader());
         temp.put(UUID.class, new Readers.UUIDReader());
+        temp.put(URL.class, new Readers.URLReader());
+
+
+
         try
         {
             Class recordClass = Class.forName("java.lang.Record");
@@ -148,6 +153,15 @@ public class JsonReader implements Closeable
         } catch (ClassNotFoundException e)
         {
             // we can just ignore it - we are at java < 16 now. This is for code compatibility Java<16
+        }
+
+        try
+        {
+            Class recordClass = Class.forName("sun.util.calendar.ZoneInfo");
+            temp.put(recordClass, new Readers.TimeZoneReader());
+        } catch (ClassNotFoundException e)
+        {
+            // we can just ignore it - time zone isn't represented as ZoneInfo in this jvm.
         }
 
         BASE_READERS = temp;

--- a/src/main/java/com/cedarsoftware/util/io/JsonWriter.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonWriter.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.net.URL;
 import java.sql.Timestamp;
 import java.util.*;
 import java.util.Map.Entry;
@@ -143,13 +144,26 @@ public class JsonWriter implements Closeable, Flushable
         temp.put(StringBuilder.class, new Writers.StringBuilderWriter());
         temp.put(StringBuffer.class, new Writers.StringBufferWriter());
         temp.put(UUID.class, new Writers.UUIDWriter());
+        temp.put(URL.class, new Writers.URLWriter());
+
+        try
+        {
+            Class zoneInfoClass = Class.forName("sun.util.calendar.ZoneInfo");
+            temp.put(zoneInfoClass, new Writers.TimeZoneWriter());
+        } catch (ClassNotFoundException e)
+        {
+           // we an ignore
+        }
+
+
+
         BASE_WRITERS = temp;
     }
 
     private static volatile boolean allowNanAndInfinity = false;
 
     /**
-     * @return boolean the allowsNanAndInifnity flag
+     * @return boolean the allowsNanAndInfinity flag
      */
     public static boolean isAllowNanAndInfinity() {
         return allowNanAndInfinity;

--- a/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
+++ b/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
@@ -107,6 +107,7 @@ public class MetaUtils
         nameToClass.put("date", Date.class);
         nameToClass.put("class", Class.class);
 
+
         // Save memory by re-using all byte instances (Bytes are immutable)
         for (int i = 0; i < byteCache.length; i++)
         {

--- a/src/main/java/com/cedarsoftware/util/io/Resolver.java
+++ b/src/main/java/com/cedarsoftware/util/io/Resolver.java
@@ -390,6 +390,10 @@ abstract class Resolver
                 {
                     mate = extractEnumSet(c, jsonObj);
                 }
+                else if (TimeZone.class.isAssignableFrom(c) && jsonObj.containsKey("zone"))
+                {
+                    mate = TimeZone.getTimeZone((String)jsonObj.get("zone"));
+                }
                 else if ((mate = coerceCertainTypes(c.getName())) != null)
                 {   // if coerceCertainTypes() returns non-null, it did the work
                 }

--- a/src/main/java/com/cedarsoftware/util/io/Writers.java
+++ b/src/main/java/com/cedarsoftware/util/io/Writers.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.io.Writer;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.net.URI;
+import java.net.URL;
 import java.sql.Timestamp;
 import java.text.Format;
 import java.text.SimpleDateFormat;
@@ -41,7 +43,23 @@ import java.util.concurrent.atomic.AtomicLong;
 public class Writers
 {
     private Writers () {}
-    
+
+    public static class URLWriter implements JsonWriter.JsonClassWriter
+    {
+        public void write(Object obj, boolean showType, Writer output) throws IOException
+        {
+            URL url = (URL) obj;
+            output.write("\"url\":");
+            writeJsonUtf8String(url.toString(), output);
+        }
+
+        public boolean hasPrimitiveForm() { return true; }
+        public void writePrimitiveForm(Object o, Writer output) throws IOException {
+            URL url = (URL) o;
+            writeJsonUtf8String(url.toString(), output);
+        }
+    }
+
     public static class TimeZoneWriter implements JsonWriter.JsonClassWriter
     {
         public void write(Object obj, boolean showType, Writer output) throws IOException
@@ -53,7 +71,10 @@ public class Writers
         }
 
         public boolean hasPrimitiveForm() { return false; }
-        public void writePrimitiveForm(Object o, Writer output) throws IOException {}
+        public void writePrimitiveForm(Object o, Writer output) throws IOException {
+            TimeZone tz = (TimeZone)o;
+            writeJsonUtf8String(tz.getID(), output);
+        }
     }
 
     public static class CalendarWriter implements JsonWriter.JsonClassWriter

--- a/src/test/groovy/com/cedarsoftware/util/io/TestAlwaysShowType.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestAlwaysShowType.groovy
@@ -1,9 +1,9 @@
 package com.cedarsoftware.util.io
 
 import com.cedarsoftware.util.DeepEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestArrays.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestArrays.groovy
@@ -2,12 +2,17 @@ package com.cedarsoftware.util.io
 
 import com.cedarsoftware.util.DeepEquals
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.lang.reflect.Array
 
 import static com.cedarsoftware.util.io.JsonObject.ITEMS
-import static org.junit.Assert.*
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertNotSame
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertSame
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestAtomicBoolean.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestAtomicBoolean.groovy
@@ -1,13 +1,14 @@
 package com.cedarsoftware.util.io
 
+import com.google.gson.JsonIOException
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.util.concurrent.atomic.AtomicBoolean
 
-import static org.junit.Assert.assertNotSame
-import static org.junit.Assert.assertNull
-import static org.junit.Assert.fail
+import static org.junit.jupiter.api.Assertions.assertNotSame
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertThrows
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -60,13 +61,7 @@ class TestAtomicBoolean
         assert json == '''{"@type":"com.cedarsoftware.util.io.TestAtomicBoolean$TestAtomicBooleanField","value":true,"nullValue":null,"strValue":true,"emptyStrValue":null,"objValue":false,"values":[false,null,true,true]}'''
 
         json = '''{"@type":"com.cedarsoftware.util.io.TestAtomicBoolean$TestAtomicBooleanField","value":16.5}'''
-        try
-        {
-            JsonReader.jsonToJava(json)
-            fail()
-        }
-        catch (JsonIoException ignored)
-        { }
+        assertThrows(JsonIoException.class, { JsonReader.jsonToJava(json) })
     }
 
     @Test

--- a/src/test/groovy/com/cedarsoftware/util/io/TestAtomicInteger.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestAtomicInteger.groovy
@@ -1,15 +1,18 @@
 package com.cedarsoftware.util.io
 
+import com.google.gson.JsonIOException
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertNotSame
-import static org.junit.Assert.assertNull
-import static org.junit.Assert.assertTrue
-import static org.junit.Assert.fail
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotSame
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
+
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -63,13 +66,7 @@ class TestAtomicInteger
 
 
         json = '''{"@type":"com.cedarsoftware.util.io.TestAtomicInteger$TestAtomicIntegerField","value":16.5}'''
-        try
-        {
-            JsonReader.jsonToJava(json)
-            fail()
-        }
-        catch (JsonIoException ignored)
-        { }
+        assertThatExceptionOfType(JsonIoException.class).isThrownBy({ JsonReader.jsonToJava(json) })
     }
 
     @Test

--- a/src/test/groovy/com/cedarsoftware/util/io/TestAtomicLong.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestAtomicLong.groovy
@@ -1,13 +1,13 @@
 package com.cedarsoftware.util.io
 
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.util.concurrent.atomic.AtomicLong
 
-import static org.junit.Assert.assertNotSame
-import static org.junit.Assert.assertNull
-import static org.junit.Assert.fail
+import static org.junit.jupiter.api.Assertions.assertNotSame
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertThrows
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -61,13 +61,7 @@ class TestAtomicLong
 
 
         json = '''{"@type":"com.cedarsoftware.util.io.TestAtomicLong$TestAtomicLongField","value":16.5}'''
-        try
-        {
-            JsonReader.jsonToJava(json)
-            fail()
-        }
-        catch (JsonIoException ignored)
-        { }
+        assertThrows(JsonIoException.class, { JsonReader.jsonToJava(json) })
     }
 
     @Test

--- a/src/test/groovy/com/cedarsoftware/util/io/TestBigDecimal.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestBigDecimal.groovy
@@ -1,13 +1,13 @@
 package com.cedarsoftware.util.io
 
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertFalse
-import static org.junit.Assert.assertNotSame
-import static org.junit.Assert.assertNull
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertNotSame
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 import static com.cedarsoftware.util.io.JsonObject.REF
 /**

--- a/src/test/groovy/com/cedarsoftware/util/io/TestBigInteger.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestBigInteger.groovy
@@ -1,13 +1,13 @@
 package com.cedarsoftware.util.io
 
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertNotSame
-import static org.junit.Assert.assertNull
-import static org.junit.Assert.assertTrue
-import static org.junit.Assert.fail
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotSame
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -178,37 +178,10 @@ class TestBigInteger
         assertNull(Readers.bigIntegerFrom(null))
         assertNull(Readers.bigDecimalFrom(null))
 
-        try
-        {
-            Readers.bigIntegerFrom("Glock")
-            fail()
-        }
-        catch(Exception ignored)
-        { }
-
-        try
-        {
-            Readers.bigDecimalFrom("Glock")
-            fail()
-        }
-        catch(Exception ignored)
-        { }
-
-        try
-        {
-            Readers.bigIntegerFrom(new Date())
-            fail()
-        }
-        catch(Exception ignored)
-        { }
-
-        try
-        {
-            Readers.bigDecimalFrom(new Date())
-            fail()
-        }
-        catch(Exception ignored)
-        { }
+        assertThrows(Exception.class, { Readers.bigIntegerFrom("Glock")})
+        assertThrows(Exception.class, { Readers.bigDecimalFrom("Glock")})
+        assertThrows(Exception.class, { Readers.bigIntegerFrom(new Date())})
+        assertThrows(Exception.class, { Readers.bigDecimalFrom(new Date())})
 
         BigInteger bi = Readers.bigIntegerFrom(3.14)
         assertEquals(3, bi.intValue())

--- a/src/test/groovy/com/cedarsoftware/util/io/TestBigJson.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestBigJson.groovy
@@ -1,11 +1,11 @@
 package com.cedarsoftware.util.io
 import com.google.gson.Gson
 import groovy.transform.CompileStatic
-import org.junit.Ignore
-import org.junit.Test
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertNotNull
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotNull
 /**
  * Test cases for JsonReader / JsonWriter
  *
@@ -56,7 +56,7 @@ class TestBigJson
         println ((stop - start) / 1000000L)
     }
 
-    @Ignore
+    @Disabled
     void testGsonOnHugeFile()
     {
         String json = TestUtil.fetchResource('big.json')
@@ -78,7 +78,7 @@ class TestBigJson
         }
     }
 
-    @Ignore
+    @Disabled
     void testJsonOnHugeFile()
     {
         String json = TestUtil.fetchResource('big.json')

--- a/src/test/groovy/com/cedarsoftware/util/io/TestBoolean.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestBoolean.groovy
@@ -1,9 +1,9 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertSame
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertSame
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestByte.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestByte.groovy
@@ -1,9 +1,9 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertSame
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertSame
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestByteArray.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestByteArray.groovy
@@ -1,8 +1,8 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestCalendars.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestCalendars.groovy
@@ -1,8 +1,8 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestCharacter.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestCharacter.groovy
@@ -1,10 +1,10 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertSame
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertSame
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestClass.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestClass.groovy
@@ -1,9 +1,9 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertSame
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertSame
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestClassForName.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestClassForName.groovy
@@ -1,9 +1,10 @@
 package com.cedarsoftware.util.io
 
+import com.google.gson.JsonIOException
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.fail
+import static org.junit.jupiter.api.Assertions.assertThrows
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -44,26 +45,14 @@ class TestClassForName
     @Test
     void testClassForNameNullClassErrorHandling()
     {
-        try
-        {
-            MetaUtils.classForName(null, TestClassForName.class.getClassLoader())
-            fail()
-        }
-        catch (JsonIoException ignored)
-        { }
-
+        assertThrows(JsonIoException.class, { MetaUtils.classForName(null, TestClassForName.class.getClassLoader()) })
         assert Map.class.isAssignableFrom(MetaUtils.classForName('Smith&Wesson', TestClassForName.class.getClassLoader()))
     }
 
     @Test
     void testClassForNameFailOnClassLoaderErrorTrue()
     {
-        try {
-            MetaUtils.classForName('foo.bar.baz.Qux', TestClassForName.class.getClassLoader(), true)
-            fail()
-        }
-        catch (JsonIoException ignored)
-        { }
+        assertThrows(JsonIoException.class, { MetaUtils.classForName('foo.bar.baz.Qux', TestClassForName.class.getClassLoader(), true) })
     }
 
     @Test
@@ -99,7 +88,7 @@ class TestClassForName
             }
             catch (Exception ignored) { }
 
-            if (alternateName.equals(className))
+            if (alternateName == className)
             {
                 return Long.class;
             }

--- a/src/test/groovy/com/cedarsoftware/util/io/TestCollection.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestCollection.groovy
@@ -1,11 +1,14 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.awt.*
 import java.util.List
 
-import static org.junit.Assert.*
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotNull
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestConstructor.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestConstructor.groovy
@@ -1,11 +1,11 @@
 package com.cedarsoftware.util.io
 
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertNull
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestCustomClassHandler.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestCustomClassHandler.groovy
@@ -1,11 +1,11 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.text.ParseException
 import java.text.SimpleDateFormat
 
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestCustomReaderIdentity.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestCustomReaderIdentity.groovy
@@ -1,6 +1,6 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestCustomReaderMap.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestCustomReaderMap.groovy
@@ -1,8 +1,8 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static junit.framework.Assert.assertEquals
+import static org.junit.jupiter.api.Assertions.assertEquals
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestCustomReaderObject.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestCustomReaderObject.groovy
@@ -1,6 +1,6 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestCustomWriter.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestCustomWriter.groovy
@@ -1,6 +1,6 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestDates.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestDates.groovy
@@ -1,14 +1,14 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.sql.Timestamp
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertNotSame
-import static org.junit.Assert.assertNull
-import static org.junit.Assert.assertTrue
-import static org.junit.Assert.fail
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotSame
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -167,15 +167,7 @@ class TestDates
         assertEquals(9, cal.get(Calendar.DAY_OF_MONTH))
 
         json = '{"@type":"date","value":"2014 Juggler 9"}'
-        try
-        {
-            JsonReader.jsonToJava(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.toLowerCase().contains("unable to parse")
-        }
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json) })
     }
 
     @Test

--- a/src/test/groovy/com/cedarsoftware/util/io/TestDeprecated.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestDeprecated.groovy
@@ -1,6 +1,6 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestDouble.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestDouble.groovy
@@ -1,8 +1,8 @@
 package com.cedarsoftware.util.io
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertNotSame
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertNotSame
+import static org.junit.jupiter.api.Assertions.assertTrue
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
  *         <br>

--- a/src/test/groovy/com/cedarsoftware/util/io/TestEnums.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestEnums.groovy
@@ -1,11 +1,11 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestErrors.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestErrors.groovy
@@ -1,10 +1,10 @@
 package com.cedarsoftware.util.io
 
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertTrue
-import static org.junit.Assert.fail
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -29,25 +29,12 @@ class TestErrors
     @Test
     void testBadJson()
     {
-        Object o = null;
-
-        try
-        {
-            o = TestUtil.readJsonObject('["bad JSON input"')
-            fail()
-        }
-        catch(Exception e)
-        {
-            assertTrue(e.message.toLowerCase().contains("expected ',' or ']' inside array"))
-        }
-        assertTrue(o == null)
+        assertThrows(Exception.class, { TestUtil.readJsonObject('["bad JSON input"')})
     }
 
     @Test
     void testParseMissingQuote()
     {
-        try
-        {
             String json = '''{
   "array": [
     1,
@@ -64,13 +51,7 @@ class TestErrors
   },
   "string: "Hello World"
 }'''
-            JsonReader.jsonToJava(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assertTrue(e.message.toLowerCase().contains("expected ':' between string field and value"))
-        }
+            assertThrows(Exception.class, { JsonReader.jsonToJava(json) })
     }
 
     @Test
@@ -99,8 +80,6 @@ class TestErrors
     @Test
     void testParseMissingLastBrace()
     {
-        try
-        {
             String json = """{
   "array": [
     1,1,1,1,1,1,1,1,1,1,
@@ -117,13 +96,7 @@ class TestErrors
   },
   "string": "Hello World"
 """
-            JsonReader.jsonToJava(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assertTrue(e.message.toLowerCase().contains("eof reached before closing '}'"))
-        }
+            assertThrows(Exception.class, { JsonReader.jsonToJava(json) })
     }
 
     @Test
@@ -132,265 +105,101 @@ class TestErrors
         String json = '[true, "bunch of ints", 1,2, 3 , 4, 5 , 6,7,8,9,10]'
         JsonReader.jsonToJava(json)
 
-        try
-        {
-            json = '[true, "bunch of ints", 1,2, 3 , 4, 5 , 6,7,8,9,10'
-            JsonReader.jsonToJava(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assertTrue(e.message.toLowerCase().contains("expected ',' or ']' inside array"))
-        }
+        json = '[true, "bunch of ints", 1,2, 3 , 4, 5 , 6,7,8,9,10'
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json) })
     }
 
     @Test
     void testParseBadValueInArray()
     {
-        String json
-
-        try
-        {
-            json = '[true, "bunch of ints", 1,2, 3 , 4, 5 , 6,7,8,9,\'a\']'
-            JsonReader.jsonToJava(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assertTrue(e.message.toLowerCase().contains("unknown json value type"))
-        }
+        String json = '[true, "bunch of ints", 1,2, 3 , 4, 5 , 6,7,8,9,\'a\']'
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json) })
     }
 
     @Test
     void testParseObjectWithoutClosingBrace()
     {
-        try
-        {
-            String json = '{"key": true{'
-            JsonReader.jsonToJava(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assertTrue(e.message.toLowerCase().contains("object not ended with '}'"))
-        }
+        String json = '{"key": true{'
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json) })
     }
 
     @Test
     void testParseBadHex()
     {
-        try
-        {
-            String json = '"\\u5h1t"'
-            JsonReader.jsonToJava(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assertTrue(e.message.toLowerCase().contains("expected hexadecimal digits"))
-        }
+        String json = '"\\u5h1t"'
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json) })
     }
 
     @Test
     void testParseBadEscapeChar()
     {
-        try
-        {
-            String json = '"What if I try to escape incorrectly \\L1CK"'
-            JsonReader.jsonToJava(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assertTrue(e.message.toLowerCase().contains("invalid character escape sequence"))
-        }
+        String json = '"What if I try to escape incorrectly \\L1CK"'
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json) })
     }
 
     @Test
     void testParseUnfinishedString()
     {
-        try
-        {
-            String json = '"This is an unfinished string...'
-            JsonReader.jsonToJava(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assertTrue(e.message.toLowerCase().contains("eof reached"))
-        }
+        String json = '"This is an unfinished string...'
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json) })
     }
 
     @Test
     void testParseEOFInToken()
     {
-        try
-        {
-            String json = "falsz"
-            JsonReader.jsonToJava(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assertTrue(e.message.toLowerCase().contains("expected token: false"))
-        }
+        String json = "falsz"
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json) })
     }
 
     @Test
     void testParseEOFReadingToken()
     {
-        try
-        {
-            String json = "tru"
-            JsonReader.jsonToJava(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assertTrue(e.message.toLowerCase().contains("eof reached while reading token: true"))
-        }
+        String json = "tru"
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json) })
     }
 
     @Test
     void testParseEOFinArray()
     {
-        try
-        {
-            String json = "[true, false,"
-            JsonReader.jsonToJava(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assertTrue(e.message.toLowerCase().contains("eof reached prematurely"))
-        }
+        String json = "[true, false,"
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json) })
     }
 
     @Test
     void testMalformedJson()
     {
-        String json;
+        String json = '{"field"0}'  // colon expected between fields
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map) })
 
-        try
-        {
-            json = '{"field"0}'  // colon expected between fields
-            JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.toLowerCase().contains("expected ':' between string field and value")
-        }
+        json = "{field:0}"  // not quoted field name
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map) })
 
-        try
-        {
-            json = "{field:0}"  // not quoted field name
-            JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.toLowerCase().contains("expected quote")
-        }
+        json = '{"field":0'  // object not terminated correctly (ending in number)
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map) })
 
-        try
-        {
-            json = '{"field":0'  // object not terminated correctly (ending in number)
-            JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.toLowerCase().contains("eof reached before closing '}'")
-        }
+        json = '{"field":true'  // object not terminated correctly (ending in token)
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map) })
 
-        try
-        {
-            json = '{"field":true'  // object not terminated correctly (ending in token)
-            JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.toLowerCase().contains("eof reached before closing '}'")
-        }
+        json = '{"field":"test"'  // object not terminated correctly (ending in string)
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map) })
 
-        try
-        {
-            json = '{"field":"test"'  // object not terminated correctly (ending in string)
-            JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.toLowerCase().contains("eof reached before closing '}'")
-        }
+        json = '{"field":{}'  // object not terminated correctly (ending in another object)
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map) })
 
-        try
-        {
-            json = '{"field":{}'  // object not terminated correctly (ending in another object)
-            JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.toLowerCase().contains("eof reached before closing '}'")
-        }
+        json = '{"field":[]'  // object not terminated correctly (ending in an array)
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map) })
 
-        try
-        {
-            json = '{"field":[]'  // object not terminated correctly (ending in an array)
-            JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.toLowerCase().contains("eof reached before closing '}'")
-        }
+        json = '{"field":3.14'  // object not terminated correctly (ending in double precision number)
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map) })
 
-        try
-        {
-            json = '{"field":3.14'  // object not terminated correctly (ending in double precision number)
-            JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.toLowerCase().contains("eof reached before closing '}'")
-        }
+        json = '[1,2,3'
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map) })
 
-        try
-        {
-            json = '[1,2,3'
-            JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.toLowerCase().contains("expected ',' or ']' inside array")
-        }
+        json = "[false,true,false"
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map) })
 
-        try
-        {
-            json = "[false,true,false"
-            JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.toLowerCase().contains("expected ',' or ']' inside array")
-        }
-
-        try
-        {
-            json = '["unclosed string]'
-            JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.toLowerCase().contains("eof reached while reading json string")
-        }
+        json = '["unclosed string]'
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map) })
     }
 
     @Test
@@ -450,74 +259,27 @@ class TestErrors
         StringBuilder str = new StringBuilder()
         str.append("[\"\\")
         str.append("u000r\"]")
-        try
-        {
-            TestUtil.readJsonObject(str.toString())
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.contains('["\\u000r')
-        }
+
+        assertThrows(Exception.class, { TestUtil.readJsonObject(str.toString() )})
     }
 
     @Test
     void testBadValue()
     {
-        try
-        {
-            String json = '{"field":19;}'
-            TestUtil.readJsonObject(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.contains('{"field":19;')
-        }
+        String json = '{"field":19;}'
+        assertThrows(Exception.class, { TestUtil.readJsonObject(json )})
 
-        try
-        {
-            String json = '{"field":'
-            TestUtil.readJsonObject(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.contains('{"field":')
-        }
+        json = '{"field":'
+        assertThrows(Exception.class, { TestUtil.readJsonObject(json )})
 
-        try
-        {
-            String json = '{"field":joe'
-            TestUtil.readJsonObject(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.contains('{"field":j')
-        }
+        json = '{"field":joe'
+        assertThrows(Exception.class, { TestUtil.readJsonObject(json )})
 
-        try
-        {
-            String json = '{"field":trux}'
-            TestUtil.readJsonObject(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.contains('{"field":trux')
-        }
+        json = '{"field":trux}'
+        assertThrows(Exception.class, { TestUtil.readJsonObject(json )})
 
-        try
-        {
-            String json = '{"field":tru'
-            TestUtil.readJsonObject(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.contains('{"field":tru')
-        }
+        json = '{"field":tru'
+        assertThrows(Exception.class, { TestUtil.readJsonObject(json )})
     }
 
     @Test
@@ -529,131 +291,58 @@ class TestErrors
         json = '["escaped slash \\/ should result in a single /"]'
         TestUtil.readJsonObject(json)
 
-        try
-        {
-            json = '["escaped slash \\x should result in a single /"]'
-            TestUtil.readJsonObject(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.contains('["escaped slash \\x')
-        }
+        json = '["escaped slash \\x should result in a single /"]'
+        assertThrows(Exception.class, { TestUtil.readJsonObject(json )})
     }
 
     @Test
     void testClassMissingValue()
     {
-        try
-        {
-            TestUtil.readJsonObject('[{"@type":"class"}]')
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.contains('lass listed')
-            assert e.message.contains('not found')
-        }
+        assertThrows(Exception.class, { TestUtil.readJsonObject('[{"@type":"class"}]' )})
     }
 
     @Test
     void testCalendarMissingValue()
     {
-        try
-        {
-            TestUtil.readJsonObject('[{"@type":"java.util.Calendar"}]')
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.contains('lass listed')
-            assert e.message.contains('not found')
-        }
+        assertThrows(Exception.class, { TestUtil.readJsonObject('[{"@type":"java.util.Calendar"}]' )})
     }
 
     @Test
     void testBadFormattedCalendar()
     {
-        try
-        {
-            TestUtil.readJsonObject('[{"@type":"java.util.GregorianCalendar","value":"2012-05-03T12:39:45.1X5-0400"}]')
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.contains('ailed to parse calendar')
-        }
+        assertThrows(Exception.class, { TestUtil.readJsonObject('[{"@type":"java.util.GregorianCalendar","value":"2012-05-03T12:39:45.1X5-0400"}]' )})
     }
 
     @Test
     void testEmptyClassName()
     {
-        try
-        {
-            TestUtil.readJsonObject('{"@type":""}')
-            fail()
-        }
-        catch(Exception e)
-        {
-            assert e.message.contains('nable to create class')
-        }
+        assertThrows(Exception.class, { TestUtil.readJsonObject('{"@type":""}' )})
     }
 
     @Test
     void testBadBackRef()
     {
-        try
-        {
-            TestUtil.readJsonObject('{"@type":"java.util.ArrayList","@items":[{"@ref":1}]}')
-            fail()
-        }
-        catch(Exception ignored)
-        { }
+        assertThrows(Exception.class, { TestUtil.readJsonObject('{"@type":"java.util.ArrayList","@items":[{"@ref":1}]}' )})
     }
 
     @Test
     void testErrorReporting()
     {
         String json = '[{"@type":"funky"},\n{"field:"value"]'
-        try
-        {
-            JsonReader.jsonToJava(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.contains("xpected ':'")
-            assert e.message.contains('"field:"v')
-        }
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json)})
     }
 
     @Test
     void testFieldMissingQuotes()
     {
-        try
-        {
-            String json = '[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, {"field":25, field2: "no quotes"}, 11, 12, 13]'
-            JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
-            fail()
-        }
-        catch (JsonIoException e)
-        {
-            assert e.message.contains('"field":25, f')
-        }
+        String json = '[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, {"field":25, field2: "no quotes"}, 11, 12, 13]'
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json)})
     }
 
     @Test
     void testBadFloatingPointNumber()
     {
-        try
-        {
-            String json = '[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, {"field":25, "field2": "no quotes"}, 11, 12.14a, 13]'
-            JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
-            fail()
-        }
-        catch (JsonIoException e)
-        {
-            assert e.message.toLowerCase().contains('expected \',\' or \']\' inside array')
-        }
+        String json = '[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, {"field":25, "field2": "no quotes"}, 11, 12.14a, 13]'
+        assertThrows(Exception.class, { JsonReader.jsonToJava(json,  [(JsonReader.USE_MAPS):true] as Map)})
     }
 }

--- a/src/test/groovy/com/cedarsoftware/util/io/TestFields.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestFields.groovy
@@ -1,9 +1,13 @@
 package com.cedarsoftware.util.io
 
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.*
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -483,15 +487,8 @@ class TestFields
 
         Map args = new HashMap()
         args.put(JsonWriter.FIELD_SPECIFIERS, fieldSpecifiers)
-        try
-        {
-            JsonWriter.objectToJson(painful, args)
-            fail("should not make it here")
-        }
-        catch (Exception e)
-        {
-            assertTrue(e.getMessage().toLowerCase().contains("unable to convert"))
-        }
+
+        assertThrows(Exception.class, {  JsonWriter.objectToJson(painful, args) })
     }
 
     @Test

--- a/src/test/groovy/com/cedarsoftware/util/io/TestFloat.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestFloat.groovy
@@ -1,13 +1,14 @@
 package com.cedarsoftware.util.io
 
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertNotEquals
-import static org.junit.Assert.assertNotSame
-import static org.junit.Assert.assertTrue
-import static org.junit.Assert.fail
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotEquals
+import static org.junit.jupiter.api.Assertions.assertNotSame
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
+
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -112,15 +113,7 @@ class TestFloat
     void parseBadFloat()
     {
         String json = '[123.45.67]'
-        try
-        {
-            JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
-            fail()
-        }
-        catch (JsonIoException e)
-        {
-            assert e.message.toLowerCase().contains('invalid number: 123.45.67')
-        }
+        assertThrows(JsonIoException.class, { JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map) })
     }
 
     @Test

--- a/src/test/groovy/com/cedarsoftware/util/io/TestForwardReferences.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestForwardReferences.groovy
@@ -1,9 +1,9 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestInnerClass.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestInnerClass.groovy
@@ -1,10 +1,8 @@
 package com.cedarsoftware.util.io
 
-import org.junit.FixMethodOrder
-import org.junit.Test
-import org.junit.runners.MethodSorters
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -23,7 +21,6 @@ import static org.junit.Assert.assertTrue
  *         See the License for the specific language governing permissions and
  *         limitations under the License.
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 class TestInnerClass
 {
     static public class A

--- a/src/test/groovy/com/cedarsoftware/util/io/TestInnerCollections.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestInnerCollections.groovy
@@ -1,7 +1,7 @@
 package com.cedarsoftware.util.io
 
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentSkipListMap

--- a/src/test/groovy/com/cedarsoftware/util/io/TestInteger.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestInteger.groovy
@@ -1,10 +1,10 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertNotSame
-import static org.junit.Assert.assertSame
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertNotSame
+import static org.junit.jupiter.api.Assertions.assertSame
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestInternalAPIs.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestInternalAPIs.groovy
@@ -1,9 +1,9 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertNotNull
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotNull
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestJavascript.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestJavascript.groovy
@@ -1,7 +1,9 @@
 package com.cedarsoftware.util.io
 
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledOnJre
+import org.junit.jupiter.api.condition.JRE
 
 import javax.script.ScriptEngine
 import javax.script.ScriptEngineManager
@@ -27,6 +29,7 @@ class TestJavascript {
     private static final ScriptEngineManager scm = new ScriptEngineManager(ClassLoader.getSystemClassLoader());
 
     @Test
+    @EnabledOnJre(value = JRE.JAVA_8, disabledReason = "java dropped support for javascript engine after 8")
     void testJsonUtilRefInsideArray() {
 
         ScriptEngine engine = scm.getEngineByName("JavaScript")
@@ -48,6 +51,7 @@ assert(array[0] === array[1]);   // Exactly the same instance
     }
 
     @Test
+    @EnabledOnJre(value = JRE.JAVA_8, disabledReason = "java dropped support for javascript engine after 8")
     void testJsonUtilForwardRefInsideArray() {
         ScriptEngine engine = scm.getEngineByName("JavaScript")
 
@@ -68,6 +72,7 @@ assert(array[0] === array[1]);   // Exactly the same instance
     }
 
     @Test
+    @EnabledOnJre(value = JRE.JAVA_8, disabledReason = "java dropped support for javascript engine after 8")
     void testJsonUtilRefInsideObject() {
         ScriptEngine engine = scm.getEngineByName("JavaScript")
 
@@ -91,6 +96,7 @@ assert(!testObj._other._other['@ref']);
     }
 
     @Test
+    @EnabledOnJre(value = JRE.JAVA_8, disabledReason = "java dropped support for javascript engine after 8")
     void testJsonUtilRefCycle() {
         ScriptEngine engine = scm.getEngineByName("JavaScript")
 

--- a/src/test/groovy/com/cedarsoftware/util/io/TestJsonIoException.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestJsonIoException.groovy
@@ -1,6 +1,6 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestJsonObject.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestJsonObject.groovy
@@ -1,9 +1,9 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertTrue
-import static org.junit.Assert.fail
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -49,13 +49,8 @@ class TestJsonObject
         assertTrue MetaUtils.isLogicalPrimitive(BigInteger.class)
         assertTrue MetaUtils.isLogicalPrimitive(BigDecimal.class)
         assertTrue MetaUtils.isLogicalPrimitive(Number.class)
-        try
-        {
-            MetaUtils.isLogicalPrimitive(null)
-            fail()
-        }
-        catch (NullPointerException ignored)
-        { }
+
+        assertThrows(NullPointerException.class, { MetaUtils.isLogicalPrimitive(null) })
     }
 
     @Test

--- a/src/test/groovy/com/cedarsoftware/util/io/TestLocale.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestLocale.groovy
@@ -1,10 +1,10 @@
 package com.cedarsoftware.util.io
 
 import com.cedarsoftware.util.DeepEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertTrue
-import static org.junit.Assert.fail
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -40,16 +40,9 @@ class TestLocale
         us = (Locale) TestUtil.readJsonObject(json)
         assertTrue(locale.equals(us))
 
-        try
-        {
-            String noProps = '{"@type":"java.util.Locale"}'
-            TestUtil.readJsonObject(noProps)
-            fail()
-        }
-        catch(Exception e)
-        {
-            assert e.message.toLowerCase().contains("must specify 'language'")
-        }
+
+        Throwable e = assertThrows(Exception.class, { TestUtil.readJsonObject('{"@type":"java.util.Locale"}') })
+        assertTrue(e.message.toLowerCase().contains("must specify 'language'"))
 
         json = '{"@type":"java.util.Locale","language":"en"}'
         locale = (Locale) TestUtil.readJsonObject(json)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestLong.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestLong.groovy
@@ -1,11 +1,11 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertNotSame
-import static org.junit.Assert.assertSame
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotSame
+import static org.junit.jupiter.api.Assertions.assertSame
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestMapOfMaps.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestMapOfMaps.groovy
@@ -1,16 +1,17 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.awt.*
 import java.util.List
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertNotSame
-import static org.junit.Assert.assertNull
-import static org.junit.Assert.assertSame
-import static org.junit.Assert.assertTrue
-import static org.junit.Assert.fail
+import static org.assertj.core.api.Assertions.assertThat
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotSame
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertSame
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * Test cases for JsonReader / JsonWriter
@@ -63,15 +64,9 @@ class TestMapOfMaps
         String testObjectClassName = TestObject.class.name
         json = '{"@type":"' + testObjectClassName + '","_name":"alpha","_other":{"@type":"com.baz.Qux","_name":"beta","_other":null}}'
 
-        try
-        {
-            JsonReader.jsonToJava(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assertTrue(e.message.toLowerCase().contains('setting field \'_other\''))
-        }
+
+        Exception e = assertThrows(Exception.class, { JsonReader.jsonToJava(json)})
+        assertThat(e.getMessage().toLowerCase()).contains('setting field \'_other\'')
 
         map = (Map) JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
         assertEquals('alpha', map._name)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestMapOutputFormat.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestMapOutputFormat.groovy
@@ -2,7 +2,7 @@ package com.cedarsoftware.util.io
 
 import com.cedarsoftware.util.DeepEquals
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Test cases for JsonReader / JsonWriter

--- a/src/test/groovy/com/cedarsoftware/util/io/TestMaps.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestMaps.groovy
@@ -2,13 +2,18 @@ package com.cedarsoftware.util.io
 
 import com.cedarsoftware.util.DeepEquals
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.awt.*
 import java.util.List
 import java.util.concurrent.ConcurrentHashMap
 
-import static org.junit.Assert.*
+import static org.assertj.core.api.Fail.fail
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertNotNull
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -176,7 +181,7 @@ class TestMaps
             }
             else
             {
-                assertTrue("Unknown key", false)
+                fail("Unknown Key");
             }
         }
 
@@ -360,28 +365,15 @@ class TestMaps
         assertTrue(map instanceof HashMap)
         assertTrue(map.isEmpty())
 
-        try
-        {
-            json = '{"@type":"java.util.HashMap","@keys":null,"@items":[]}'
-            TestUtil.readJsonObject(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.toLowerCase().contains('@keys or @items')
-            assert e.message.toLowerCase().contains('empty')
-        }
 
-        try
-        {
-            json = '{"@type":"java.util.HashMap","@keys":[1,2],"@items":[true]}'
-            TestUtil.readJsonObject(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            assert e.message.toLowerCase().contains("different size")
-        }
+        json = '{"@type":"java.util.HashMap","@keys":null,"@items":[]}'
+        Exception e = assertThrows(Exception.class, { TestUtil.readJsonObject(json)})
+        assert e.message.toLowerCase().contains('@keys or @items')
+        assert e.message.toLowerCase().contains('empty')
+
+        json = '{"@type":"java.util.HashMap","@keys":[1,2],"@items":[true]}'
+        e = assertThrows(Exception.class, { TestUtil.readJsonObject(json) })
+        assert e.message.toLowerCase().contains("different size")
     }
 
     @Test
@@ -454,13 +446,7 @@ class TestMaps
         assert map.a == 'alpha'
         assert map.b == 'beta'
 
-        try
-        {
-            map = (Map) JsonReader.jsonToJava('{"a":"alpha", "b":"beta"}', [(JsonReader.UNKNOWN_OBJECT):(Object)Boolean.FALSE]);
-            fail()
-        }
-        catch (JsonIoException expected)
-        { }
+        assertThrows(JsonIoException.class, {JsonReader.jsonToJava('{"a":"alpha", "b":"beta"}', [(JsonReader.UNKNOWN_OBJECT):(Object)Boolean.FALSE]) })
     }
 
     @Test

--- a/src/test/groovy/com/cedarsoftware/util/io/TestMapsToClasses.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestMapsToClasses.groovy
@@ -1,6 +1,6 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger

--- a/src/test/groovy/com/cedarsoftware/util/io/TestMetaUtils.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestMetaUtils.groovy
@@ -1,10 +1,10 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.sql.Timestamp
 
-import static org.junit.Assert.assertFalse
+import static org.junit.jupiter.api.Assertions.assertFalse
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestMissingFieldHandler.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestMissingFieldHandler.groovy
@@ -2,9 +2,10 @@ package com.cedarsoftware.util.io
 
 import groovy.transform.CompileStatic
 
-import static org.junit.Assert.*
+import org.junit.jupiter.api.Test
 
-import org.junit.Test
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestNoId.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestNoId.groovy
@@ -1,8 +1,8 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertFalse
+import static org.junit.jupiter.api.Assertions.assertFalse
 import static com.cedarsoftware.util.io.JsonObject.ID
 
 /**

--- a/src/test/groovy/com/cedarsoftware/util/io/TestNoType.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestNoType.groovy
@@ -1,6 +1,6 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestNonUtf8.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestNonUtf8.groovy
@@ -1,7 +1,7 @@
 package com.cedarsoftware.util.io
 
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.nio.charset.Charset
 

--- a/src/test/groovy/com/cedarsoftware/util/io/TestObjectHolder.java
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestObjectHolder.java
@@ -1,11 +1,11 @@
 package com.cedarsoftware.util.io;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Kai Hufenbach

--- a/src/test/groovy/com/cedarsoftware/util/io/TestOverflow.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestOverflow.groovy
@@ -1,9 +1,9 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertThrows
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 class TestOverflow
 {
@@ -32,6 +32,6 @@ class TestOverflow
     void testOverflow()
     {
         Throwable thrown = assertThrows(JsonIoException.class, { JsonReader.jsonToJava(TOO_DEEP_DOC) })
-        assertTrue("", thrown.message.contains("Maximum parsing depth exceeded"))
+        assertTrue(thrown.message.contains("Maximum parsing depth exceeded"))
     }
 }

--- a/src/test/groovy/com/cedarsoftware/util/io/TestOverlappingMemberVariableNames.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestOverlappingMemberVariableNames.groovy
@@ -1,8 +1,8 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertEquals
+import static org.junit.jupiter.api.Assertions.assertEquals
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestPrettyPrint.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestPrettyPrint.groovy
@@ -1,10 +1,10 @@
 package com.cedarsoftware.util.io
 
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertNotEquals
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotEquals
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestPrimitives.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestPrimitives.groovy
@@ -1,12 +1,11 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertFalse
-import static org.junit.Assert.assertNull
-import static org.junit.Assert.assertTrue
-import static org.junit.Assert.fail
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestProcessBuilder.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestProcessBuilder.groovy
@@ -1,6 +1,6 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class TestProcessBuilder
 {

--- a/src/test/groovy/com/cedarsoftware/util/io/TestReader.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestReader.groovy
@@ -1,7 +1,7 @@
 package com.cedarsoftware.util.io
 
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestRefs.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestRefs.groovy
@@ -1,10 +1,10 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertNull
-import static org.junit.Assert.assertSame
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertSame
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestRoots.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestRoots.groovy
@@ -2,10 +2,10 @@ package com.cedarsoftware.util.io
 
 import com.google.gson.Gson
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.junit.jupiter.api.Assertions.assertEquals
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestSet.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestSet.groovy
@@ -1,10 +1,10 @@
 package com.cedarsoftware.util.io
 
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
  *         <br>

--- a/src/test/groovy/com/cedarsoftware/util/io/TestShort.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestShort.groovy
@@ -1,10 +1,10 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertNotSame
-import static org.junit.Assert.assertSame
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertNotSame
+import static org.junit.jupiter.api.Assertions.assertSame
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestShortMetaNames.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestShortMetaNames.groovy
@@ -1,7 +1,7 @@
 package com.cedarsoftware.util.io
 
 import com.cedarsoftware.util.DeepEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestString.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestString.groovy
@@ -1,12 +1,12 @@
 package com.cedarsoftware.util.io
 
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertNotSame
-import static org.junit.Assert.assertSame
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotSame
+import static org.junit.jupiter.api.Assertions.assertSame
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -47,7 +47,7 @@ class TestString
             StringBuffer s = new StringBuffer()
             for (int i = 0; i < MAX_UTF8_CHAR; i++)
             {
-                s.append((char) i)
+                s.append(i as char)
             }
             _range = s.toString()
 
@@ -80,7 +80,7 @@ class TestString
 
         for (int i = 0; i < ManyStrings.MAX_UTF8_CHAR; i++)
         {
-            assertTrue(that._range.charAt(i) == (char) i)
+            assertTrue(that._range.charAt(i) == (i as char))
         }
 
         // UTF-8 serialization makes it through clean.

--- a/src/test/groovy/com/cedarsoftware/util/io/TestTemplateFields.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestTemplateFields.groovy
@@ -1,11 +1,11 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.awt.Point
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertNull
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNull
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestTransient.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestTransient.groovy
@@ -1,9 +1,14 @@
 package com.cedarsoftware.util.io
 
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.*
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType
+import static org.assertj.core.api.Assertions.assertThatNoException
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -61,14 +66,8 @@ class TestTransient
         assert json.contains('lname')
         assert json.contains('fullname')
 
-        try
-        {
-            TestUtil.getJsonString(person, [(JsonWriter.FIELD_SPECIFIERS):[(Transient1.class):['fname', 'lname', 'map']]] as Map)
-        }
-        catch (UnsupportedOperationException unused)
-        {
-            fail('Although the Map throws UnsupportedOperation, JsonWriter should catch this and continue')
-        }
+        //'Although the Map throws UnsupportedOperation, JsonWriter should catch this and continue'
+        assertThatNoException().isThrownBy({TestUtil.getJsonString(person, [(JsonWriter.FIELD_SPECIFIERS):[(Transient1.class):['fname', 'lname', 'map']]] as Map) })
     }
 
     @Test

--- a/src/test/groovy/com/cedarsoftware/util/io/TestTypeSubstitution.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestTypeSubstitution.groovy
@@ -1,7 +1,7 @@
 package com.cedarsoftware.util.io
 
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestUUID.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestUUID.groovy
@@ -1,10 +1,13 @@
 package com.cedarsoftware.util.io
 
 import groovy.transform.CompileStatic
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.*
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertSame
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
+
 
 /**
  * @author Balazs Bessenyei (h143570@gmail.com)
@@ -46,16 +49,16 @@ class TestUUID
         assertEquals((Object) UUID.fromString("6508db3c-52c5-42ad-91f3-621d6e1d6557"), tu.internals)
 
         json = '{"@type":"' + TestUUIDFields.class.name + '","fromString":""}'
-        Throwable thrown = Assert.assertThrows(JsonIoException.class, { (TestUUIDFields) TestUtil.readJsonObject(json) })
+        Throwable thrown = assertThrows(JsonIoException.class, { TestUtil.readJsonObject(json) })
         assertEquals(IllegalArgumentException.class, thrown.cause.class)
 
         json = '{"@type":"' + TestUUIDFields.class.name + '", "internals": {"@type": "java.util.UUID", "leastSigBits":-7929886640328317609}}'
-        thrown = Assert.assertThrows(JsonIoException.class, { (TestUUIDFields) TestUtil.readJsonObject(json) })
-        assertTrue("", thrown.cause.message.contains("mostSigBits"))
+        thrown = assertThrows(JsonIoException.class, { TestUtil.readJsonObject(json) })
+        assertTrue(thrown.cause.message.contains("mostSigBits"))
 
         json = '{"@type":"' + TestUUIDFields.class.name + '", "internals": {"@type": "java.util.UUID", "mostSigBits":7280309849777586861}}'
-        thrown = Assert.assertThrows(JsonIoException.class, { (TestUUIDFields) TestUtil.readJsonObject(json) })
-        assertTrue("", thrown.cause.message.contains("leastSigBits"))
+        thrown = assertThrows(JsonIoException.class, { TestUtil.readJsonObject(json) })
+        assertTrue(thrown.cause.message.contains("leastSigBits"))
     }
 
     @Test

--- a/src/test/groovy/com/cedarsoftware/util/io/TestUnknownObjectType.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestUnknownObjectType.groovy
@@ -1,8 +1,11 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import com.google.gson.JsonIOException
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.fail
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -55,11 +58,6 @@ class TestUnknownObjectType
     void testUnknownClassTypeFailsWhenFailOptionTrue()
     {
         def json = '{"@type":"foo.bar.baz.Qux", "name":"Joe"}'
-        try {
-            JsonReader.jsonToJava(json, [(JsonReader.FAIL_ON_UNKNOWN_TYPE): true ])
-            fail()
-        }
-        catch (JsonIoException expected) {
-        }
+        assertThrows(JsonIoException.class, { JsonReader.jsonToJava(json, [(JsonReader.FAIL_ON_UNKNOWN_TYPE): true]) });
     }
 }

--- a/src/test/groovy/com/cedarsoftware/util/io/TestUnmodifiableCollection.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestUnmodifiableCollection.groovy
@@ -1,6 +1,6 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Test cases for JsonReader / JsonWriter

--- a/src/test/groovy/com/cedarsoftware/util/io/TestUsingSunMisc.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestUsingSunMisc.groovy
@@ -1,9 +1,9 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertTrue
-import static org.junit.Assert.fail
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -105,26 +105,10 @@ class TestUsingSunMisc
     @Test
     void testImpossibleClass()
     {
-        try
-        {
-            ShouldBeImpossibleToInstantiate s = new ShouldBeImpossibleToInstantiate()
-            fail()
-        }
-        catch (Exception e)
-        {
-            e.message.toLowerCase().concat("go away")
-        }
+        assertThrows(Exception.class, { new ShouldBeImpossibleToInstantiate() })
 
         String json = '{"@type":"' + ShouldBeImpossibleToInstantiate.class.name + '", "x":50}'
-        try
-        {
-            JsonReader.jsonToJava(json)
-            fail()
-        }
-        catch (Exception e)
-        {
-            e.message.toLowerCase().concat("go away")
-        }
+        assertThrows(Exception.class, {  JsonReader.jsonToJava(json) })
 
         MetaUtils.useUnsafe = true
         ShouldBeImpossibleToInstantiate s = JsonReader.jsonToJava(json)

--- a/src/test/groovy/com/cedarsoftware/util/io/TestWithAtSignInData.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestWithAtSignInData.groovy
@@ -1,8 +1,8 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.fail
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -24,23 +24,17 @@ import static org.junit.Assert.fail
 class TestWithAtSignInData
 {
     @Test
-    public void testFormatThatUsesAtSign()
+    void testFormatThatUsesAtSign()
     {
         String json = '{"PrincipalName":{"@type":"fir:IndividualNameType","NamePrefix":{"NamePrefixText":"Ms"},"FirstName":"Marge","LastName":"Simpson","FullName":"Marge Simpson"},"JobTitle":[{"JobTitleText":{"$":"President"}}],"CurrentManagementResponsibility":[{"ManagementResponsibilityText":{"@ManagementResponsibilityCode":"A1A6","$":"President"}}],"PrincipalIdentificationNumberDetail":[{"@DNBCodeValue":24226,"@TypeText":"Professional Contact Identifier","PrincipalIdentificationNumber":"178125299"}]}'
 
-        try
-        {
-            Map map = (Map) JsonReader.jsonToJava(json)
-            assert (map.CurrentManagementResponsibility instanceof Object[])
-            assert map.PrincipalName.NamePrefix.NamePrefixText == 'Ms'
-            assert map.PrincipalIdentificationNumberDetail[0]['@DNBCodeValue'] == 24226
-        }
-        catch (JsonIoException ignore)
-        {
-            fail('should not fail with an unknown @type')
-        }
+        Map map;
+        assertThatNoException().isThrownBy ({ map = (Map)JsonReader.jsonToJava(json); })
+        assert (map.CurrentManagementResponsibility instanceof Object[])
+        assert map.PrincipalName.NamePrefix.NamePrefixText == 'Ms'
+        assert map.PrincipalIdentificationNumberDetail[0]['@DNBCodeValue'] == 24226
 
-        Map map = JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
+        map = JsonReader.jsonToJava(json, [(JsonReader.USE_MAPS):true] as Map)
         assert (map.CurrentManagementResponsibility instanceof Object[])
         assert map.PrincipalName.NamePrefix.NamePrefixText == 'Ms'
         assert map.PrincipalIdentificationNumberDetail[0]['@DNBCodeValue'] == 24226

--- a/src/test/groovy/com/cedarsoftware/util/io/TestWriters.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestWriters.groovy
@@ -1,9 +1,9 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-import static org.junit.Assert.assertFalse
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -27,9 +27,6 @@ class TestWriters
     @Test
     void testUnusedAPIs()
     {
-        Writers.TimeZoneWriter tzw = new Writers.TimeZoneWriter()
-        tzw.writePrimitiveForm("", new StringWriter())
-
         Writers.CalendarWriter cw = new Writers.CalendarWriter()
         cw.writePrimitiveForm("", new StringWriter())
 

--- a/src/test/groovy/com/cedarsoftware/util/io/TestZLast.groovy
+++ b/src/test/groovy/com/cedarsoftware/util/io/TestZLast.groovy
@@ -1,6 +1,6 @@
 package com.cedarsoftware.util.io
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Last test to run, dumps out statistics

--- a/src/test/java/com/cedarsoftware/util/io/GenericSubObject.java
+++ b/src/test/java/com/cedarsoftware/util/io/GenericSubObject.java
@@ -1,0 +1,11 @@
+package com.cedarsoftware.util.io;
+
+public class GenericSubObject<T> {
+    private T object;
+
+    public GenericSubObject(T object) {
+        this.object = object;
+    }
+
+    public T getObject() { return this.object; }
+}

--- a/src/test/java/com/cedarsoftware/util/io/TestArgumentHelper.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestArgumentHelper.java
@@ -1,0 +1,75 @@
+package com.cedarsoftware.util.io;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigInteger;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestArgumentHelper {
+    @ParameterizedTest
+    @MethodSource("argumentHelperTrueValues")
+    void argumentHelper_truthyValues_returnTrue(Object input) {
+        assertThat(ArgumentHelper.isTrue(input)).isTrue();
+    }
+
+    @ParameterizedTest
+    @MethodSource("argumentHelperFalseValues")
+    void argumentHelper_nonTruthyValues_returnFalse(Object input) {
+        assertThat(ArgumentHelper.isTrue(input)).isFalse();
+    }
+
+
+    private static Stream<Arguments> argumentHelperTrueValues() {
+        return Stream.of(
+                Arguments.of(Boolean.TRUE),
+                Arguments.of("true"),
+                Arguments.of(Long.valueOf(999)),
+                Arguments.of(Integer.valueOf(5)),
+                Arguments.of(BigInteger.valueOf(1)),
+                Arguments.of(Byte.valueOf("1", 10)),
+                Arguments.of(Double.valueOf(1.0))
+        );
+    }
+
+    private static Stream<Arguments> argumentHelperFalseValues() {
+        return Stream.of(
+                Arguments.of(Boolean.FALSE),
+                Arguments.of("false"),
+                Arguments.of("foo"),
+                Arguments.of(Long.valueOf(0)),
+                Arguments.of(Integer.valueOf(0)),
+                Arguments.of((byte)0),
+                Arguments.of(Double.valueOf(0)),
+                Arguments.of(new TestArgumentHelper())
+        );
+    }
+
+
+
+    public static boolean isTrue(Object setting)
+    {
+        if (setting instanceof Boolean)
+        {
+            return Boolean.TRUE.equals(setting);
+        }
+
+        if (setting instanceof String)
+        {
+            return "true".equalsIgnoreCase((String) setting);
+        }
+
+        if (setting instanceof Number)
+        {
+            return ((Number)setting).intValue() != 0;
+        }
+
+        return false;
+    }
+}

--- a/src/test/java/com/cedarsoftware/util/io/TestEmptyEnumSetOnJDK17.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestEmptyEnumSetOnJDK17.java
@@ -1,6 +1,6 @@
 package com.cedarsoftware.util.io;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.EnumSet;
 import java.util.Objects;

--- a/src/test/java/com/cedarsoftware/util/io/TestEmptyListForJdk17.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestEmptyListForJdk17.java
@@ -3,8 +3,9 @@ package com.cedarsoftware.util.io;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -32,8 +33,8 @@ public class TestEmptyListForJdk17 {
         String json = JsonWriter.objectToJson(o);
         List es = (List) JsonReader.jsonToJava(json);
 
-        Assert.assertTrue(es.isEmpty());
-        Assert.assertEquals(Collections.EMPTY_LIST.getClass(), es.getClass());
+        assertTrue(es.isEmpty());
+        assertEquals(Collections.EMPTY_LIST.getClass(), es.getClass());
     }
 
 }

--- a/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleCycleButJsonIoCan.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleCycleButJsonIoCan.java
@@ -1,9 +1,9 @@
 package com.cedarsoftware.util.io;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -44,16 +44,8 @@ public class TestGsonNotHandleCycleButJsonIoCan
         beta.next = alpha;
 
         // Google blows the stack when there is a cycle in the data
-        try
-        {
-            Gson gson = new Gson();
-            String json = gson.toJson(alpha);
-            fail();
-        }
-        catch(StackOverflowError e)
-        {
-            // Expected with gson
-        }
+
+        assertThrows(StackOverflowError.class, () -> new Gson().toJson(alpha));
 
         // json-io handles cycles just fine.
         String json = JsonWriter.objectToJson(alpha);

--- a/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleHeteroCollections.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleHeteroCollections.java
@@ -1,14 +1,11 @@
 package com.cedarsoftware.util.io;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-
-import static junit.framework.TestCase.fail;
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleMapWithNonStringKeysButJsonIoCan.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleMapWithNonStringKeysButJsonIoCan.java
@@ -1,7 +1,7 @@
 package com.cedarsoftware.util.io;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.awt.*;
 import java.util.LinkedHashMap;

--- a/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleStaticInnerButJsonIoCan.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestGsonNotHandleStaticInnerButJsonIoCan.java
@@ -1,9 +1,9 @@
 package com.cedarsoftware.util.io;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)

--- a/src/test/java/com/cedarsoftware/util/io/TestJDK9Immutable.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestJDK9Immutable.java
@@ -4,8 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestJDK9Immutable {
 
@@ -29,8 +30,8 @@ public class TestJDK9Immutable {
         String json = JsonWriter.objectToJson(o);
         List<?> es = (List<?>) JsonReader.jsonToJava(json);
 
-        Assert.assertEquals(0, es.size());
-        Assert.assertEquals(o.getClass(), es.getClass());
+        assertEquals(0, es.size());
+        assertEquals(o.getClass(), es.getClass());
     }
 
     @Test
@@ -40,8 +41,8 @@ public class TestJDK9Immutable {
         String json = JsonWriter.objectToJson(o);
         List<?> es = (List<?>) JsonReader.jsonToJava(json);
 
-        Assert.assertEquals(0, es.size());
-        Assert.assertEquals(o.getClass(), es.getClass());
+        assertEquals(0, es.size());
+        assertEquals(o.getClass(), es.getClass());
     }
 
     @Test
@@ -51,8 +52,8 @@ public class TestJDK9Immutable {
         String json = JsonWriter.objectToJson(o);
         List<?> es = (List<?>) JsonReader.jsonToJava(json);
 
-        Assert.assertEquals(1, es.size());
-        Assert.assertEquals(o.getClass(), es.getClass());
+        assertEquals(1, es.size());
+        assertEquals(o.getClass(), es.getClass());
     }
 
     @Test
@@ -62,8 +63,8 @@ public class TestJDK9Immutable {
         String json = JsonWriter.objectToJson(o);
         List<?> es = (List<?>) JsonReader.jsonToJava(json);
 
-        Assert.assertEquals(2, es.size());
-        Assert.assertEquals(o.getClass(), es.getClass());
+        assertEquals(2, es.size());
+        assertEquals(o.getClass(), es.getClass());
     }
 
     @Test
@@ -73,8 +74,8 @@ public class TestJDK9Immutable {
         String json = JsonWriter.objectToJson(o);
         List<?> es = (List<?>) JsonReader.jsonToJava(json);
 
-        Assert.assertEquals(3, es.size());
-        Assert.assertEquals(o.getClass(), es.getClass());
+        assertEquals(3, es.size());
+        assertEquals(o.getClass(), es.getClass());
     }
 
     @Test
@@ -84,8 +85,8 @@ public class TestJDK9Immutable {
         String json = JsonWriter.objectToJson(o);
         Set<?> es = (Set<?>) JsonReader.jsonToJava(json);
 
-        Assert.assertEquals(0, es.size());
-        Assert.assertEquals(o.getClass(), es.getClass());
+        assertEquals(0, es.size());
+        assertEquals(o.getClass(), es.getClass());
     }
 
     @Test
@@ -95,8 +96,8 @@ public class TestJDK9Immutable {
         String json = JsonWriter.objectToJson(o);
         Set<?> es = (Set<?>) JsonReader.jsonToJava(json);
 
-        Assert.assertEquals(1, es.size());
-        Assert.assertEquals(o.getClass(), es.getClass());
+        assertEquals(1, es.size());
+        assertEquals(o.getClass(), es.getClass());
     }
 
     @Test
@@ -106,8 +107,8 @@ public class TestJDK9Immutable {
         String json = JsonWriter.objectToJson(o);
         Set<?> es = (Set<?>) JsonReader.jsonToJava(json);
 
-        Assert.assertEquals(2, es.size());
-        Assert.assertEquals(o.getClass(), es.getClass());
+        assertEquals(2, es.size());
+        assertEquals(o.getClass(), es.getClass());
     }
 
     @Test
@@ -117,8 +118,8 @@ public class TestJDK9Immutable {
         String json = JsonWriter.objectToJson(o);
         Set<?> es = (Set<?>) JsonReader.jsonToJava(json);
 
-        Assert.assertEquals(3, es.size());
-        Assert.assertEquals(o.getClass(), es.getClass());
+        assertEquals(3, es.size());
+        assertEquals(o.getClass(), es.getClass());
     }
 
     @Test
@@ -134,22 +135,22 @@ public class TestJDK9Immutable {
         String json = JsonWriter.objectToJson(ol);
         List<Rec> recs = (List<Rec>) JsonReader.jsonToJava(json);
 
-        Assert.assertEquals(ol.getClass(), recs.getClass());
-        Assert.assertEquals(ol.size(), recs.size());
+        assertEquals(ol.getClass(), recs.getClass());
+        assertEquals(ol.size(), recs.size());
 
-        Assert.assertEquals(ol.get(0).s, recs.get(0).s);
-        Assert.assertEquals(ol.get(0).i, recs.get(0).i);
-        Assert.assertEquals(recs.get(1), recs.get(0).link);
-        Assert.assertEquals(ol.get(1).s, recs.get(1).s);
-        Assert.assertEquals(ol.get(1).i, recs.get(1).i);
-        Assert.assertEquals(recs.get(0), recs.get(1).link);
+        assertEquals(ol.get(0).s, recs.get(0).s);
+        assertEquals(ol.get(0).i, recs.get(0).i);
+        assertEquals(recs.get(1), recs.get(0).link);
+        assertEquals(ol.get(1).s, recs.get(1).s);
+        assertEquals(ol.get(1).i, recs.get(1).i);
+        assertEquals(recs.get(0), recs.get(1).link);
 
-        Assert.assertEquals(recs.get(0), recs.get(2));
+        assertEquals(recs.get(0), recs.get(2));
 
-        Assert.assertEquals(ol.get(0).mlinks.size(), recs.get(0).mlinks.size());
-        Assert.assertEquals(ol.get(0).mlinks.getClass(), recs.get(0).mlinks.getClass());
-        Assert.assertEquals(ol.get(1).mlinks.size(), recs.get(1).mlinks.size());
-        Assert.assertEquals(ol.get(1).mlinks.getClass(), recs.get(1).mlinks.getClass());
+        assertEquals(ol.get(0).mlinks.size(), recs.get(0).mlinks.size());
+        assertEquals(ol.get(0).mlinks.getClass(), recs.get(0).mlinks.getClass());
+        assertEquals(ol.get(1).mlinks.size(), recs.get(1).mlinks.size());
+        assertEquals(ol.get(1).mlinks.getClass(), recs.get(1).mlinks.getClass());
     }
 
     @Test
@@ -165,22 +166,22 @@ public class TestJDK9Immutable {
         String json = JsonWriter.objectToJson(ol);
         List<Rec> recs = (List<Rec>) JsonReader.jsonToJava(json);
 
-        Assert.assertEquals(ol.getClass(), recs.getClass());
-        Assert.assertEquals(ol.size(), recs.size());
+        assertEquals(ol.getClass(), recs.getClass());
+        assertEquals(ol.size(), recs.size());
 
-        Assert.assertEquals(ol.get(0).s, recs.get(0).s);
-        Assert.assertEquals(ol.get(0).i, recs.get(0).i);
-        Assert.assertEquals(recs.get(1), recs.get(0).link);
-        Assert.assertEquals(ol.get(1).s, recs.get(1).s);
-        Assert.assertEquals(ol.get(1).i, recs.get(1).i);
-        Assert.assertEquals(recs.get(0), recs.get(1).link);
+        assertEquals(ol.get(0).s, recs.get(0).s);
+        assertEquals(ol.get(0).i, recs.get(0).i);
+        assertEquals(recs.get(1), recs.get(0).link);
+        assertEquals(ol.get(1).s, recs.get(1).s);
+        assertEquals(ol.get(1).i, recs.get(1).i);
+        assertEquals(recs.get(0), recs.get(1).link);
 
-        Assert.assertEquals(recs.get(0), recs.get(2));
+        assertEquals(recs.get(0), recs.get(2));
 
-        Assert.assertEquals(ol.get(0).mlinks.size(), recs.get(0).mlinks.size());
-        Assert.assertEquals(ol.get(0).mlinks.getClass(), recs.get(0).mlinks.getClass());
-        Assert.assertEquals(ol.get(1).mlinks.size(), recs.get(1).mlinks.size());
-        Assert.assertEquals(ol.get(1).mlinks.getClass(), recs.get(1).mlinks.getClass());
+        assertEquals(ol.get(0).mlinks.size(), recs.get(0).mlinks.size());
+        assertEquals(ol.get(0).mlinks.getClass(), recs.get(0).mlinks.getClass());
+        assertEquals(ol.get(1).mlinks.size(), recs.get(1).mlinks.size());
+        assertEquals(ol.get(1).mlinks.getClass(), recs.get(1).mlinks.getClass());
     }
 
     @Test
@@ -198,29 +199,29 @@ public class TestJDK9Immutable {
         String json = JsonWriter.objectToJson(ol);
         Object es = (List) JsonReader.jsonToJava(json);
 
-        Assert.assertEquals(((Object) ol).getClass(), es.getClass());
+        assertEquals(((Object) ol).getClass(), es.getClass());
 
         List<Rec> recs = (List<Rec>) es;
-        Assert.assertEquals(ol.size(), recs.size());
+        assertEquals(ol.size(), recs.size());
 
-        Assert.assertEquals(ol.get(0).s, recs.get(0).s);
-        Assert.assertEquals(ol.get(0).i, recs.get(0).i);
-        Assert.assertEquals(recs.get(1), recs.get(0).link);
-        Assert.assertEquals(ol.get(1).s, recs.get(1).s);
-        Assert.assertEquals(ol.get(1).i, recs.get(1).i);
-        Assert.assertEquals(recs.get(0), recs.get(1).link);
+        assertEquals(ol.get(0).s, recs.get(0).s);
+        assertEquals(ol.get(0).i, recs.get(0).i);
+        assertEquals(recs.get(1), recs.get(0).link);
+        assertEquals(ol.get(1).s, recs.get(1).s);
+        assertEquals(ol.get(1).i, recs.get(1).i);
+        assertEquals(recs.get(0), recs.get(1).link);
 
-        Assert.assertEquals(recs.get(0), recs.get(2));
+        assertEquals(recs.get(0), recs.get(2));
 
-        Assert.assertEquals(ol.get(0).mlinks.size(), recs.get(0).mlinks.size());
-        Assert.assertEquals(ol.get(0).mlinks.getClass(), recs.get(0).mlinks.getClass());
-        Assert.assertEquals(ol.get(1).mlinks.size(), recs.get(1).mlinks.size());
-        Assert.assertEquals(ol.get(1).mlinks.getClass(), recs.get(1).mlinks.getClass());
+        assertEquals(ol.get(0).mlinks.size(), recs.get(0).mlinks.size());
+        assertEquals(ol.get(0).mlinks.getClass(), recs.get(0).mlinks.getClass());
+        assertEquals(ol.get(1).mlinks.size(), recs.get(1).mlinks.size());
+        assertEquals(ol.get(1).mlinks.getClass(), recs.get(1).mlinks.getClass());
 
-        Assert.assertEquals(ol.get(0).ilinks.getClass(), recs.get(0).ilinks.getClass());
-        Assert.assertEquals(ol.get(0).ilinks.size(), recs.get(0).ilinks.size());
-        Assert.assertEquals(ol.get(1).ilinks.getClass(), recs.get(1).ilinks.getClass());
-        Assert.assertEquals(ol.get(1).ilinks.size(), recs.get(1).ilinks.size());
+        assertEquals(ol.get(0).ilinks.getClass(), recs.get(0).ilinks.getClass());
+        assertEquals(ol.get(0).ilinks.size(), recs.get(0).ilinks.size());
+        assertEquals(ol.get(1).ilinks.getClass(), recs.get(1).ilinks.getClass());
+        assertEquals(ol.get(1).ilinks.size(), recs.get(1).ilinks.size());
     }
 
     @Test
@@ -234,21 +235,21 @@ public class TestJDK9Immutable {
         String json = JsonWriter.objectToJson(ol);
         Object es = JsonReader.jsonToJava(json);
 
-        Assert.assertEquals(((Object) ol).getClass(), es.getClass());
+        assertEquals(((Object) ol).getClass(), es.getClass());
 
         List<Rec> recs = (List<Rec>) es;
-        Assert.assertEquals(ol.size(), recs.size());
+        assertEquals(ol.size(), recs.size());
 
-        Assert.assertEquals(ol.get(0).s, recs.get(0).s);
-        Assert.assertEquals(ol.get(0).i, recs.get(0).i);
-        Assert.assertEquals(ol.get(1).s, recs.get(1).s);
-        Assert.assertEquals(ol.get(1).i, recs.get(1).i);
+        assertEquals(ol.get(0).s, recs.get(0).s);
+        assertEquals(ol.get(0).i, recs.get(0).i);
+        assertEquals(ol.get(1).s, recs.get(1).s);
+        assertEquals(ol.get(1).i, recs.get(1).i);
 
-        Assert.assertEquals(recs.get(0), recs.get(2));
+        assertEquals(recs.get(0), recs.get(2));
 
-        Assert.assertEquals(ol.get(0).ilinks.getClass(), recs.get(0).ilinks.getClass());
-        Assert.assertEquals(ol.get(0).ilinks.size(), recs.get(0).ilinks.size());
-        Assert.assertEquals(ol.get(1).ilinks.getClass(), recs.get(1).ilinks.getClass());
-        Assert.assertEquals(ol.get(1).ilinks.size(), recs.get(1).ilinks.size());
+        assertEquals(ol.get(0).ilinks.getClass(), recs.get(0).ilinks.getClass());
+        assertEquals(ol.get(0).ilinks.size(), recs.get(0).ilinks.size());
+        assertEquals(ol.get(1).ilinks.getClass(), recs.get(1).ilinks.getClass());
+        assertEquals(ol.get(1).ilinks.size(), recs.get(1).ilinks.size());
     }
 }

--- a/src/test/java/com/cedarsoftware/util/io/TestLenientNanInfinity.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestLenientNanInfinity.java
@@ -1,11 +1,12 @@
 package com.cedarsoftware.util.io;
 
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
-
-import org.junit.BeforeClass;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -29,7 +30,7 @@ public class TestLenientNanInfinity
     static boolean readAllowNan;
     static boolean writeAllowNan;
 
-    @BeforeClass
+    @BeforeAll
     public static void init()
     {
         readAllowNan = JsonReader.isAllowNanAndInfinity();
@@ -38,7 +39,7 @@ public class TestLenientNanInfinity
         JsonWriter.setAllowNanAndInfinity(true);
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown()
     {
         JsonReader.setAllowNanAndInfinity(readAllowNan);

--- a/src/test/java/com/cedarsoftware/util/io/TestNotLenientNanInfinity.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestNotLenientNanInfinity.java
@@ -1,11 +1,10 @@
 package com.cedarsoftware.util.io;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.BeforeClass;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -26,7 +25,7 @@ import org.junit.BeforeClass;
  */
 public class TestNotLenientNanInfinity
 {
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         JsonReader.setAllowNanAndInfinity(false);
         JsonWriter.setAllowNanAndInfinity(false);

--- a/src/test/java/com/cedarsoftware/util/io/TestSimpleValues.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestSimpleValues.java
@@ -3,11 +3,11 @@
  */
 package com.cedarsoftware.util.io;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  *         <br>
@@ -86,13 +86,13 @@ public class TestSimpleValues
     static boolean readAllowNan;
     static boolean writeAllowNan;
 
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         readAllowNan = JsonReader.isAllowNanAndInfinity();
         writeAllowNan = JsonWriter.isAllowNanAndInfinity();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown()
     {
         JsonReader.setAllowNanAndInfinity(readAllowNan);

--- a/src/test/java/com/cedarsoftware/util/io/TestURL.java
+++ b/src/test/java/com/cedarsoftware/util/io/TestURL.java
@@ -1,0 +1,142 @@
+package com.cedarsoftware.util.io;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.URL;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestURL {
+
+    private static final String LOCALHOST = "http://localhost";
+    private static final String OUTSIDE_DOMAIN = "https://foo.bar.com";
+
+    private static Stream<Arguments> argumentsForOldFormatValidation() {
+        return Stream.of(
+                Arguments.of("old-format-file-relative-path.json", "file:/path/to/file"),
+                Arguments.of("old-format-file-server-path.json", "file://servername/path/to/file.json"),
+                Arguments.of("old-format-ftp-full-with-port.json", "ftp://user:password@host:8192/foo/bar.txt"),
+                Arguments.of("old-format-ftp-user-no-password.json", "ftp://user@bar.com/foo/bar.txt"),
+                Arguments.of("old-format-ftp-user-password.json", "ftp://user:password@bar.com/foo/bar.txt"),
+                Arguments.of("old-format-http-host-file-with-parameters-and-ref.json", "http://domain.com:8080/file/path/filename.html?key=value&extra=more#AnchorLocation"),
+                Arguments.of("old-format-http-host-path-file-with-parameters.json", "https://localhost:80/some/path?foo=1&bar=2&qux=pickle"),
+                Arguments.of("old-format-http-host-path-ref.json", "http://domain.com:8080/file/path/filename.html#AnchorLocation"),
+                Arguments.of("old-format-http-host-port.json", "http://localhost:8080"),
+                Arguments.of("old-format-http-host-port-file.json", "https://localhost:80/some/path"),
+                Arguments.of("old-format-http-localhost.json", LOCALHOST),
+                Arguments.of("old-format-http-with-encoded-param.json", "https://foo.bar.com/path/file.html?text=Hello+G%C3%BCnter"),
+                Arguments.of("old-format-http-with-encoded-path.json", "https://foo.bar.com/path/foo%20bar.html"),
+                Arguments.of("old-format-https-host-external.json", "https://google.com"),
+                Arguments.of("old-format-jar.json", "jar:file:/c://my.jar!/"),
+                Arguments.of("old-format-jar-file.json", "jar:file:/c://my.jar!/com/mycompany/MyClass.class")
+        );
+    }
+    @ParameterizedTest
+    @MethodSource("argumentsForOldFormatValidation")
+    void testUrl_readingJsonWithOldFormat_stillWorks(String fileName, String expectedUrl) throws Exception
+    {
+        String json = TestUtil.fetchResource("url/" + fileName);
+        URL actual = (URL) TestUtil.readJsonObject(json);
+
+        assertThat(actual.toString()).isEqualTo(expectedUrl);
+    }
+
+    private static Stream<Arguments> argumentsForUrlTesting() {
+        return Stream.of(
+                Arguments.of("https://domain.com"),
+                Arguments.of("http://localhost"),
+                Arguments.of("http://localhost:8080"),
+                Arguments.of("http://localhost:8080/file/path"),
+                Arguments.of("http://localhost:8080/path/file.html"),
+                Arguments.of("http://localhost:8080/path/file.html?foo=1&bar=2"),
+                Arguments.of("http://localhost:8080/path/file.html?foo=bar&qux=quy#AnchorLocation"),
+                Arguments.of("https://foo.bar.com/"),
+                Arguments.of("https://foo.bar.com/path/foo%20bar.html"),
+                Arguments.of("https://foo.bar.com/path/file.html?text=Hello+G%C3%BCnter"),
+                Arguments.of("ftp://user@bar.com/foo/bar.txt"),
+                Arguments.of("ftp://user:password@host/foo/bar.txt"),
+                Arguments.of("ftp://user:password@host:8192/foo/bar.txt"),
+                Arguments.of("file:/path/to/file"),
+                Arguments.of("file://localhost/path/to/file.json"),
+                Arguments.of("file://servername/path/to/file.json"),
+                Arguments.of("jar:file:/c://my.jar!/"),
+                Arguments.of("jar:file:/c://my.jar!/com/mycompany/MyClass.class")
+        );
+    }
+    @ParameterizedTest
+    @MethodSource("argumentsForUrlTesting")
+    void testToString_withDifferentUrls_works(String input) throws Exception {
+        URL url = new URL(input);
+        assertThat(url.toString()).isEqualTo(input);
+    }
+
+    @ParameterizedTest
+    @MethodSource("argumentsForUrlTesting")
+    void testSerialization_withDifferentUrls_works(String input) throws Exception {
+        URL url = new URL(input);
+        String json = TestUtil.getJsonString(url);
+
+        TestUtil.printLine("json=" + json);
+        Object read = TestUtil.readJsonObject(json);
+        assertThat(read).isEqualTo(url);
+    }
+
+    @Test
+    void testURL_hasTypeAndUrl_and_noOtherUrlParams() throws Exception {
+        URL url = new URL(OUTSIDE_DOMAIN);
+        String json = TestUtil.getJsonString(url);
+        assertThatJsonIsNewStyle(json);
+    }
+
+    private static void assertThatJsonIsNewStyle(String json) {
+        assertThat(json).contains("url")
+                .contains("@type")
+                .doesNotContain("protocol")
+                .doesNotContain("file")
+                .doesNotContain("ref")
+                .doesNotContain("authority")
+                .doesNotContain("host")
+                .doesNotContain("port");
+    }
+
+    @Test
+    void testUrl_inGenericSubobject_serializeBackCorrectly() throws Exception {
+        URL url = new URL(LOCALHOST);
+        GenericSubObject initial = new GenericSubObject<>(url);
+        String json = TestUtil.getJsonString(initial);
+
+        TestUtil.printLine("json=" + json);
+        GenericSubObject actual = (GenericSubObject)TestUtil.readJsonObject(json);
+        assertThat(actual.getObject()).isEqualTo(initial.getObject());
+    }
+
+    @Test
+    void testUrl_inNestedObject_serializeBackCorrectly() throws Exception {
+        URL url = new URL(OUTSIDE_DOMAIN);
+        NestedUrl initial = new NestedUrl(url);
+        String json = TestUtil.getJsonString(initial);
+        assertThatJsonIsNewStyle(json);
+
+        TestUtil.printLine("json=" + json);
+        NestedUrl actual = (NestedUrl)TestUtil.readJsonObject(json);
+
+        assertThat(actual.getUrl()).isEqualTo(initial.getUrl());
+    }
+
+    private static class NestedUrl {
+        private final URL url;
+
+        public NestedUrl(URL url) {
+            this.url = url;
+        }
+
+        public URL getUrl() {
+            return this.url;
+        }
+    }
+}

--- a/src/test/resources/timezone/timezone-away-from-est.json
+++ b/src/test/resources/timezone/timezone-away-from-est.json
@@ -1,0 +1,1 @@
+{"@type":"sun.util.calendar.ZoneInfo","zone":"Africa/Casablanca"}

--- a/src/test/resources/timezone/zoneinfo-with-type-and-zone.json
+++ b/src/test/resources/timezone/zoneinfo-with-type-and-zone.json
@@ -1,0 +1,1 @@
+{"@type":"sun.util.calendar.ZoneInfo","zone":"America/New_York"}

--- a/src/test/resources/timezone/zoneinfo-zone.json
+++ b/src/test/resources/timezone/zoneinfo-zone.json
@@ -1,0 +1,1 @@
+{"@type":"sun.util.calendar.ZoneInfo","zone":"EST"}

--- a/src/test/resources/url/old-format-file-relative-path.json
+++ b/src/test/resources/url/old-format-file-relative-path.json
@@ -1,0 +1,1 @@
+{"@type":"java.net.URL","protocol":"file","host":"","port":-1,"file":"/path/to/file","authority":null,"ref":null,"hashCode":null}

--- a/src/test/resources/url/old-format-file-server-path.json
+++ b/src/test/resources/url/old-format-file-server-path.json
@@ -1,0 +1,1 @@
+{"@type":"java.net.URL","protocol":"file","host":"servername","port":-1,"file":"/path/to/file.json","authority":"servername","ref":null,"hashCode":null}

--- a/src/test/resources/url/old-format-ftp-full-with-port.json
+++ b/src/test/resources/url/old-format-ftp-full-with-port.json
@@ -1,0 +1,1 @@
+{"@type":"java.net.URL","protocol":"ftp","host":"host","port":8192,"file":"/foo/bar.txt","authority":"user:password@host:8192","ref":null,"hashCode":null}

--- a/src/test/resources/url/old-format-ftp-user-no-password.json
+++ b/src/test/resources/url/old-format-ftp-user-no-password.json
@@ -1,0 +1,1 @@
+{"@type":"java.net.URL","protocol":"ftp","host":"bar.com","port":-1,"file":"/foo/bar.txt","authority":"user@bar.com","ref":null,"hashCode":null}

--- a/src/test/resources/url/old-format-ftp-user-password.json
+++ b/src/test/resources/url/old-format-ftp-user-password.json
@@ -1,0 +1,1 @@
+{"@type":"java.net.URL","protocol":"ftp","host":"bar.com","port":-1,"file":"/foo/bar.txt","authority":"user:password@bar.com","ref":null,"hashCode":null}

--- a/src/test/resources/url/old-format-http-host-file-with-parameters-and-ref.json
+++ b/src/test/resources/url/old-format-http-host-file-with-parameters-and-ref.json
@@ -1,0 +1,1 @@
+{"@type":"java.net.URL","protocol":"http","host":"domain.com","port":8080,"file":"/file/path/filename.html?key=value&extra=more","authority":"domain.com:8080","ref":"AnchorLocation","hashCode":null}

--- a/src/test/resources/url/old-format-http-host-path-file-with-parameters.json
+++ b/src/test/resources/url/old-format-http-host-path-file-with-parameters.json
@@ -1,0 +1,1 @@
+{"@type":"java.net.URL","protocol":"https","host":"localhost","port":80,"file":"/some/path?foo=1&bar=2&qux=pickle","authority":"localhost:80","ref":null,"hashCode":null}

--- a/src/test/resources/url/old-format-http-host-path-ref.json
+++ b/src/test/resources/url/old-format-http-host-path-ref.json
@@ -1,0 +1,1 @@
+{"@type":"java.net.URL","protocol":"http","host":"domain.com","port":8080,"file":"/file/path/filename.html","authority":"domain.com:8080","ref":"AnchorLocation","hashCode":null}

--- a/src/test/resources/url/old-format-http-host-port-file.json
+++ b/src/test/resources/url/old-format-http-host-port-file.json
@@ -1,0 +1,1 @@
+{"@type":"java.net.URL","protocol":"https","host":"localhost","port":80,"file":"/some/path","authority":"localhost:80","ref":null,"hashCode":null}

--- a/src/test/resources/url/old-format-http-host-port.json
+++ b/src/test/resources/url/old-format-http-host-port.json
@@ -1,0 +1,1 @@
+{"@type":"java.net.URL","protocol":"http","host":"localhost","port":8080,"file":"","authority":"localhost:8080","ref":null,"hashCode":null}

--- a/src/test/resources/url/old-format-http-localhost.json
+++ b/src/test/resources/url/old-format-http-localhost.json
@@ -1,0 +1,1 @@
+{"@type":"java.net.URL","protocol":"http","host":"localhost","port":-1,"file":"","authority":"localhost","ref":null,"hashCode":null}

--- a/src/test/resources/url/old-format-http-with-encoded-param.json
+++ b/src/test/resources/url/old-format-http-with-encoded-param.json
@@ -1,0 +1,1 @@
+{"@type":"java.net.URL","protocol":"https","host":"foo.bar.com","port":-1,"file":"/path/file.html?text=Hello+G%C3%BCnter","authority":"foo.bar.com","ref":null,"hashCode":null}

--- a/src/test/resources/url/old-format-http-with-encoded-path.json
+++ b/src/test/resources/url/old-format-http-with-encoded-path.json
@@ -1,0 +1,1 @@
+{"@type":"java.net.URL","protocol":"https","host":"foo.bar.com","port":-1,"file":"/path/foo%20bar.html","authority":"foo.bar.com","ref":null,"hashCode":null}

--- a/src/test/resources/url/old-format-https-host-external.json
+++ b/src/test/resources/url/old-format-https-host-external.json
@@ -1,0 +1,1 @@
+{"@type":"java.net.URL","protocol":"https","host":"google.com","port":-1,"file":"","authority":"google.com","ref":null,"hashCode":null}

--- a/src/test/resources/url/old-format-jar-file.json
+++ b/src/test/resources/url/old-format-jar-file.json
@@ -1,0 +1,1 @@
+{"@type":"java.net.URL","protocol":"jar","host":"","port":-1,"file":"file:/c://my.jar!/com/mycompany/MyClass.class","authority":null,"ref":null,"hashCode":null}

--- a/src/test/resources/url/old-format-jar.json
+++ b/src/test/resources/url/old-format-jar.json
@@ -1,0 +1,1 @@
+{"@type":"java.net.URL","protocol":"jar","host":"","port":-1,"file":"file:/c://my.jar!/","authority":null,"ref":null,"hashCode":null}


### PR DESCRIPTION
* Changed Target compilation to 9 since some items were 9 specific (Set.of, List.of, etc.)  We'll have to conditionally compile those items to go back to 1.8
* Upgraded to JUnit 5
* Added Custom Writers for types that can't deserialize in Java-11+ because of stronger field protection (URL, TimeZone)
* Added support for single-parameter url and timezone
* Added tests for old formats to make sure we still support them (old url and timezone).