### PR TITLE
Turned on Lombox in POM, remove typing from JsonObject

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,12 +265,12 @@
     </build>
 
     <dependencies>
-<!--        <dependency>-->
-<!--            <groupId>org.projectlombok</groupId>-->
-<!--            <artifactId>lombok</artifactId>-->
-<!--            <version>${version.lombok}</version>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${version.lombok}</version>
+            <scope>provided</scope>
+        </dependency>
         
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/cedarsoftware/util/io/FastPushbackBufferedReader.java
+++ b/src/main/java/com/cedarsoftware/util/io/FastPushbackBufferedReader.java
@@ -1,5 +1,7 @@
 package com.cedarsoftware.util.io;
 
+import lombok.Getter;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
@@ -14,7 +16,9 @@ public class FastPushbackBufferedReader extends BufferedReader implements FastPu
     private final int[] buf = new int[256];
     private int idx = 0;
     private int unread = Integer.MAX_VALUE;
+    @Getter
     protected int line = 1;
+    @Getter
     protected int col = 0;
 
     public FastPushbackBufferedReader(Reader reader)
@@ -109,15 +113,5 @@ public class FastPushbackBufferedReader extends BufferedReader implements FastPu
         {
             idx--;
         }
-    }
-
-    public int getCol()
-    {
-        return col;
-    }
-
-    public int getLine()
-    {
-        return line;
     }
 }

--- a/src/main/java/com/cedarsoftware/util/io/JsonObject.java
+++ b/src/main/java/com/cedarsoftware/util/io/JsonObject.java
@@ -1,7 +1,15 @@
 package com.cedarsoftware.util.io;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.lang.reflect.Array;
-import java.util.*;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * This class holds a JSON object in a LinkedHashMap.
@@ -29,7 +37,7 @@ import java.util.*;
  *         See the License for the specific language governing permissions and
  *         limitations under the License.*
  */
-public class JsonObject<K, V> extends LinkedHashMap<K, V>
+public class JsonObject extends LinkedHashMap<Object, Object>
 {
     public static final String KEYS = "@keys";
     public static final String ITEMS = "@items";
@@ -47,13 +55,30 @@ public class JsonObject<K, V> extends LinkedHashMap<K, V>
     static Set<String> primitives = new HashSet<>();
     static Set<String> primitiveWrappers = new HashSet<>();
 
+    @Getter
+    @Setter
     Object target;
     boolean isMap = false;
 
     boolean isFinished = false;
+    @Getter
+    @Setter
     String type;
+    @Getter
     long id = -1;
+    /**
+     * -- GETTER --
+     *
+     * @return int line where this object '{' started in the JSON stream
+     */
+    @Getter
     int line;
+    /**
+     * -- GETTER --
+     *
+     * @return int column where this object '{' started in the JSON stream
+     */
+    @Getter
     int col;
 
     static
@@ -81,30 +106,10 @@ public class JsonObject<K, V> extends LinkedHashMap<K, V>
     {
         return "mLen:" + getLenientSize() + " type:" + type + " line:" + line + ", col:" + col + " id:" + id;
     }
-    
-    public long getId()
-    {
-        return id;
-    }
 
     public boolean hasId()
     {
         return id != -1;
-    }
-
-    public void setType(String type)
-    {
-        this.type = type;
-    }
-
-    public String getType()
-    {
-        return type;
-    }
-
-    public Object getTarget()
-    {
-        return target;
     }
 
     public boolean isFinished() { return isFinished; }
@@ -114,12 +119,6 @@ public class JsonObject<K, V> extends LinkedHashMap<K, V>
         this.target = o;
         this.isFinished = isFinished;
         return this.target;
-    }
-
-    public Object setTarget(Object target)
-    {
-        this.target = target;
-        return target;
     }
 
     public Class<?> getTargetClass()
@@ -318,7 +317,7 @@ public class JsonObject<K, V> extends LinkedHashMap<K, V>
         }
     }
 
-    public V put(K key, V value)
+    public Object put(Object key, Object value)
     {
         if (key == null)
         {
@@ -329,13 +328,13 @@ public class JsonObject<K, V> extends LinkedHashMap<K, V>
         {
             String oldType = type;
             type = (String) value;
-            return (V) oldType;
+            return oldType;
         }
         else if (key.equals(ID))
         {
             Long oldId = id;
             id = (Long) value;
-            return (V) oldId;
+            return oldId;
         }
         else if ((ITEMS.equals(key) && containsKey(KEYS)) || (KEYS.equals(key) && containsKey(ITEMS)))
         {
@@ -345,7 +344,7 @@ public class JsonObject<K, V> extends LinkedHashMap<K, V>
     }
 
     public Object setValue(Object o) {
-        return this.put((K) VALUE, (V) o);
+        return this.put(VALUE, o);
     }
 
     public Object getValue() {
@@ -361,22 +360,6 @@ public class JsonObject<K, V> extends LinkedHashMap<K, V>
     void clearArray()
     {
         remove(ITEMS);
-    }
-
-    /**
-     * @return int line where this object '{' started in the JSON stream
-     */
-    public int getLine()
-    {
-        return line;
-    }
-
-    /**
-     * @return int column where this object '{' started in the JSON stream
-     */
-    public int getCol()
-    {
-        return col;
     }
 
     public int size()

--- a/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
+++ b/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
@@ -1,19 +1,45 @@
 package com.cedarsoftware.util.io;
 
-import java.lang.reflect.*;
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TimeZone;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static java.lang.reflect.Modifier.*;
+import static java.lang.reflect.Modifier.isPrivate;
+import static java.lang.reflect.Modifier.isProtected;
+import static java.lang.reflect.Modifier.isPublic;
 
 /**
  * This utility class has the methods mostly related to reflection related code.
@@ -162,7 +188,7 @@ public class MetaUtils
 
                 if (field.getDeclaringClass().isAssignableFrom(Enum.class))
                 {   // For Enum fields, do not add .hash or .ordinal fields to output
-                    if ("hash".equals(fieldName) || "ordinal".equals(fieldName))
+                    if ("hash".equals(fieldName) || "ordinal".equals(fieldName) || "internal".equals(fieldName))
                     {
                         continue;
                     }

--- a/src/main/java/com/cedarsoftware/util/io/ObjectResolver.java
+++ b/src/main/java/com/cedarsoftware/util/io/ObjectResolver.java
@@ -85,7 +85,7 @@ public class ObjectResolver extends Resolver
      * @param stack   Stack (Deque) used for graph traversal.
      * @param jsonObj a Map-of-Map representation of the current object being examined (containing all fields).
      */
-    public void traverseFields(final Deque<JsonObject<String, Object>> stack, final JsonObject<String, Object> jsonObj)
+    public void traverseFields(final Deque<JsonObject> stack, final JsonObject jsonObj)
     {
         this.traverseFields(stack, jsonObj, JsonWriter.EMPTY_SET);
     }
@@ -97,16 +97,16 @@ public class ObjectResolver extends Resolver
      * @param stack   Stack (Deque) used for graph traversal.
      * @param jsonObj a Map-of-Map representation of the current object being examined (containing all fields).
      */
-    public void traverseFields(final Deque<JsonObject<String, Object>> stack, final JsonObject<String, Object> jsonObj, Set<String> excludeFields)
+    public void traverseFields(final Deque<JsonObject> stack, final JsonObject jsonObj, Set<String> excludeFields)
     {
         final Object javaMate = jsonObj.target;
-        final Iterator<Map.Entry<String, Object>> i = jsonObj.entrySet().iterator();
+        final Iterator<Map.Entry<Object, Object>> i = jsonObj.entrySet().iterator();
         final Class cls = javaMate.getClass();
 
         while (i.hasNext())
         {
-            Map.Entry<String, Object> e = i.next();
-            String key = e.getKey();
+            Map.Entry<Object, Object> e = i.next();
+            String key = (String) e.getKey();
             final Field field = MetaUtils.getField(cls, key);
             Object rhs = e.getValue();
             if (field != null)
@@ -137,7 +137,7 @@ public class ObjectResolver extends Resolver
      * @param rhs     the JSON value that will be converted and stored in the 'field' on the associated
      *                Java target object.
      */
-    protected void assignField(final Deque<JsonObject<String, Object>> stack, final JsonObject jsonObj,
+    protected void assignField(final Deque<JsonObject> stack, final JsonObject jsonObj,
                                final Field field, final Object rhs)
     {
         final Object target = jsonObj.target;
@@ -307,7 +307,7 @@ public class ObjectResolver extends Resolver
      * @param rhs the JSON value that will be converted and stored in the 'field' on the associated Java target object.
      * @param missingField name of the missing field in the java object.
      */
-    protected void handleMissingField(final Deque<JsonObject<String, Object>> stack, final JsonObject<String, Object> jsonObj, final Object rhs,
+    protected void handleMissingField(final Deque<JsonObject> stack, final JsonObject jsonObj, final Object rhs,
                                       final String missingField)
     {
         final Object target = jsonObj.target;
@@ -418,7 +418,7 @@ public class ObjectResolver extends Resolver
      * unresolved references are added via .add().
      * @param jsonObj a Map-of-Map representation of the JSON input stream.
      */
-    protected void traverseCollection(final Deque<JsonObject<String, Object>> stack, final JsonObject<String, Object> jsonObj)
+    protected void traverseCollection(final Deque<JsonObject> stack, final JsonObject jsonObj)
     {
         final String className = jsonObj.type;
         final Object[] items = jsonObj.getArray();
@@ -572,7 +572,7 @@ public class ObjectResolver extends Resolver
      * @param stack   a Stack (Deque) used to support graph traversal.
      * @param jsonObj a Map-of-Map representation of the JSON input stream.
      */
-    protected void traverseArray(final Deque<JsonObject<String, Object>> stack, final JsonObject<String, Object> jsonObj)
+    protected void traverseArray(final Deque<JsonObject> stack, final JsonObject jsonObj)
     {
         final int len = jsonObj.getLength();
         if (len == 0)
@@ -647,7 +647,7 @@ public class ObjectResolver extends Resolver
                 }
                 else
                 {
-                    JsonObject<String, Object> jsonObject = new JsonObject<String, Object>();
+                    JsonObject jsonObject = new JsonObject();
                     jsonObject.put(ITEMS, element);
                     Array.set(array, i, createJavaObjectInstance(compType, jsonObject));
                     stack.addFirst(jsonObject);
@@ -655,7 +655,7 @@ public class ObjectResolver extends Resolver
             }
             else if (element instanceof JsonObject)
             {
-                JsonObject<String, Object> jsonObject = (JsonObject<String, Object>) element;
+                JsonObject jsonObject = (JsonObject) element;
                 Long ref = jsonObject.getReferenceId();
 
                 if (ref != null)
@@ -704,7 +704,7 @@ public class ObjectResolver extends Resolver
      * @param stack   a Stack (Deque) used to support graph traversal.
      * @return Java object converted from the passed in object o, or if there is no custom reader.
      */
-    protected Object readIfMatching(final Object o, final Class compType, final Deque<JsonObject<String, Object>> stack)
+    protected Object readIfMatching(final Object o, final Class compType, final Deque<JsonObject> stack)
     {
         if (o == null)
         {
@@ -793,6 +793,7 @@ public class ObjectResolver extends Resolver
             } else {
                 job = new JsonObject();
                 job.setValue(o);
+                job.setType(c.getName());
             }
 
             Object target = classFactory.newInstance(c, job);
@@ -910,11 +911,11 @@ public class ObjectResolver extends Resolver
                 {
                     if (instance instanceof JsonObject)
                     {
-                        final JsonObject<String, Object> jObj = (JsonObject) instance;
+                        final JsonObject jObj = (JsonObject) instance;
 
-                        for (Map.Entry<String, Object> entry : jObj.entrySet())
+                        for (Map.Entry<Object, Object> entry : jObj.entrySet())
                         {
-                            final String fieldName = entry.getKey();
+                            final String fieldName = (String) entry.getKey();
                             if (!fieldName.startsWith("this$"))
                             {
                                 // TODO: If more than one type, need to associate correct typeArgs entry to value

--- a/src/main/java/com/cedarsoftware/util/io/Readers.java
+++ b/src/main/java/com/cedarsoftware/util/io/Readers.java
@@ -8,7 +8,17 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.sql.Timestamp;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -86,7 +96,7 @@ public class Readers
 
     public static class URLReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object o, Deque<JsonObject> stack, Map<String, Object> args)
         {
             boolean isString = o instanceof String;
 
@@ -154,7 +164,7 @@ public class Readers
 
     public static class EnumReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object o, Deque<JsonObject> stack, Map<String, Object> args)
         {
             try
             {
@@ -171,7 +181,7 @@ public class Readers
             }
         }
 
-        Object createEnumFromJsonObject(JsonObject jObj, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        Object createEnumFromJsonObject(JsonObject jObj, Deque<JsonObject> stack, Map<String, Object> args)
         {
             String type = jObj.type;
             ClassLoader loader = (ClassLoader)args.get(JsonReader.CLASSLOADER);
@@ -182,7 +192,7 @@ public class Readers
             jObj.target = getEnum(cls.orElse(c), jObj);
 
             ObjectResolver resolver = (ObjectResolver) args.get(JsonReader.OBJECT_RESOLVER);
-            resolver.traverseFields(stack, (JsonObject<String, Object>) jObj, Set.of("name", "ordinal"));
+            resolver.traverseFields(stack, (JsonObject) jObj, Set.of("name", "ordinal", "internal"));
             Object target = ((JsonObject) jObj).getTarget();
             return target;
         }
@@ -199,7 +209,7 @@ public class Readers
 
     public static class LocaleReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object o, Deque<JsonObject> stack, Map<String, Object> args)
         {
             JsonObject jObj = (JsonObject) o;
             Object language = jObj.get("language");
@@ -227,7 +237,7 @@ public class Readers
 
     public static class CalendarReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args, JsonReader reader)
+        public Object read(Object o, Deque<JsonObject> stack, Map<String, Object> args, JsonReader reader)
         {
             String time = null;
             try
@@ -269,7 +279,7 @@ public class Readers
 
     public static class DateReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object o, Deque<JsonObject> stack, Map<String, Object> args)
         {
             if (o instanceof Long)
             {
@@ -514,7 +524,7 @@ public class Readers
 
     public static class SqlDateReader extends DateReader
     {
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object o, Deque<JsonObject> stack, Map<String, Object> args)
         {
             return new java.sql.Date(((Date) super.read(o, stack, args)).getTime());
         }
@@ -522,7 +532,7 @@ public class Readers
 
     public static class StringReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object o, Deque<JsonObject> stack, Map<String, Object> args)
         {
             if (o instanceof String)
             {
@@ -546,7 +556,7 @@ public class Readers
 
     public static class ClassReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object o, Deque<JsonObject> stack, Map<String, Object> args)
         {
             if (o instanceof String)
             {
@@ -565,7 +575,7 @@ public class Readers
 
     public static class AtomicBooleanReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object o, Deque<JsonObject> stack, Map<String, Object> args)
         {
             Object value = o;
             value = getValueFromJsonObject(o, value, "AtomicBoolean");
@@ -593,7 +603,7 @@ public class Readers
 
     public static class AtomicIntegerReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object o, Deque<JsonObject> stack, Map<String, Object> args)
         {
             Object value = o;
             value = getValueFromJsonObject(o, value, "AtomicInteger");
@@ -617,7 +627,7 @@ public class Readers
 
     public static class AtomicLongReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object o, Deque<JsonObject> stack, Map<String, Object> args)
         {
             Object value = o;
             value = getValueFromJsonObject(o, value, "AtomicLong");
@@ -658,7 +668,7 @@ public class Readers
 
     public static class BigIntegerReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object o, Deque<JsonObject> stack, Map<String, Object> args)
         {
             JsonObject jObj = null;
             Object value = o;
@@ -764,7 +774,7 @@ public class Readers
 
     public static class BigDecimalReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object o, Deque<JsonObject> stack, Map<String, Object> args)
         {
             JsonObject jObj = null;
             Object value = o;
@@ -863,7 +873,7 @@ public class Readers
 
     public static class StringBuilderReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object o, Deque<JsonObject> stack, Map<String, Object> args)
         {
             if (o instanceof String)
             {
@@ -882,7 +892,7 @@ public class Readers
 
     public static class StringBufferReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object o, Deque<JsonObject> stack, Map<String, Object> args)
         {
             if (o instanceof String)
             {
@@ -901,7 +911,7 @@ public class Readers
 
     public static class TimestampReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object o, Deque<JsonObject> stack, Map<String, Object> args)
         {
             JsonObject jObj = (JsonObject) o;
             Object time = jObj.get("time");
@@ -925,7 +935,7 @@ public class Readers
 
     public static class UUIDReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object o, Deque<JsonObject> stack, Map<String, Object> args)
         {
 
             // to use the String representation
@@ -956,7 +966,7 @@ public class Readers
     public static class RecordReader implements JsonReader.JsonClassReader
     {
         @Override
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object o, Deque<JsonObject> stack, Map<String, Object> args)
         {
             try
             {

--- a/src/main/java/com/cedarsoftware/util/io/Writers.java
+++ b/src/main/java/com/cedarsoftware/util/io/Writers.java
@@ -13,7 +13,13 @@ import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
-import java.util.*;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.UUID;
 
 /**
  * All custom writers for json-io subclass this class.  Special writers are not needed for handling
@@ -277,7 +283,7 @@ public class Writers
             output.write("\"name\":");
             writeJsonUtf8String(((Enum)obj).name(), output);
             JsonWriter writer = getWriter(args);
-            writer.writeObject(obj, true, true, Set.of("name", "ordinal"));
+            writer.writeObject(obj, true, true, Set.of("name", "ordinal", "internal"));
         }
     }
 

--- a/src/main/java/com/cedarsoftware/util/io/factory/AbstractTemporalFactory.java
+++ b/src/main/java/com/cedarsoftware/util/io/factory/AbstractTemporalFactory.java
@@ -17,7 +17,7 @@ public abstract class AbstractTemporalFactory<T extends TemporalAccessor> implem
     }
 
     @Override
-    public T newInstance(Class<?> c, JsonObject<String, Object> job) {
+    public T newInstance(Class<?> c, JsonObject job) {
         Object value = job.get("value");
 
         if (value instanceof String) {
@@ -37,7 +37,7 @@ public abstract class AbstractTemporalFactory<T extends TemporalAccessor> implem
         throw new IllegalArgumentException("Long Timestamps are not supported for this Temporal class");
     }
 
-    protected abstract T fromJsonObject(JsonObject<String, Object> job);
+    protected abstract T fromJsonObject(JsonObject job);
 
     @Override
     public boolean isObjectFinal() {

--- a/src/main/java/com/cedarsoftware/util/io/factory/ZonedDateTimeFactory.java
+++ b/src/main/java/com/cedarsoftware/util/io/factory/ZonedDateTimeFactory.java
@@ -24,18 +24,18 @@ public class ZonedDateTimeFactory extends AbstractTemporalFactory<ZonedDateTime>
     }
 
     @Override
-    protected ZonedDateTime fromJsonObject(JsonObject<String, Object> job) {
+    protected ZonedDateTime fromJsonObject(JsonObject job) {
         var dateTime = (String) job.get("dateTime");
         var localDateTime = LocalDateTime.parse(dateTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
 
 
-        var zone = (JsonObject<String, Object>) job.get("zone");
+        var zone = (JsonObject) job.get("zone");
         String id = checkReferences(zone, "id");
         var zoneId = ZoneId.of(id);
 
 
         // need to be able to process references for offset and zone.
-        var offsetMap = (JsonObject<String, Object>) job.get("offset");
+        var offsetMap = (JsonObject) job.get("offset");
         Number totalSeconds = checkReferences(offsetMap, "totalSeconds");
         if (totalSeconds == null) {
             return ZonedDateTime.of(localDateTime, zoneId);
@@ -44,7 +44,7 @@ public class ZonedDateTimeFactory extends AbstractTemporalFactory<ZonedDateTime>
         return ZonedDateTime.ofStrict(localDateTime, ZoneOffset.ofTotalSeconds(totalSeconds.intValue()), zoneId);
     }
 
-    private <T> T checkReferences(JsonObject<String, Object> job, String key) {
+    private <T> T checkReferences(JsonObject job, String key) {
         if (job == null) {
             return null;
         }

--- a/src/test/java/com/cedarsoftware/util/io/CustomClassHandlerTest.java
+++ b/src/test/java/com/cedarsoftware/util/io/CustomClassHandlerTest.java
@@ -6,9 +6,13 @@ import java.io.IOException;
 import java.io.Writer;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.Date;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -89,7 +93,7 @@ public class CustomClassHandlerTest
 
     public static class WeirdDateReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object o, Deque<JsonObject<String, Object>> stack)
+        public Object read(Object o, Deque<JsonObject> stack)
         {
             if (o instanceof String)
             {

--- a/src/test/java/com/cedarsoftware/util/io/CustomReaderIdentityTest.java
+++ b/src/test/java/com/cedarsoftware/util/io/CustomReaderIdentityTest.java
@@ -2,7 +2,13 @@ package com.cedarsoftware.util.io;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -121,7 +127,7 @@ public class CustomReaderIdentityTest
 
 	public static class CustomDataReader implements JsonReader.JsonClassReader
 	{
-		public Object read(Object jOb, Deque<JsonObject<String, Object>> stack)
+        public Object read(Object jOb, Deque<JsonObject> stack)
 		{
 			CustomDataClass customClass = new CustomDataClass();
 			customClass.setTest("blab");

--- a/src/test/java/com/cedarsoftware/util/io/CustomReaderMapTest.java
+++ b/src/test/java/com/cedarsoftware/util/io/CustomReaderMapTest.java
@@ -1,9 +1,14 @@
 package com.cedarsoftware.util.io;
 
-import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -93,7 +98,7 @@ public class CustomReaderMapTest
 
     private static class CustomPointReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object obj, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object obj, Deque<JsonObject> stack, Map<String, Object> args)
         {
             JsonObject jObj = (JsonObject) obj;
 

--- a/src/test/java/com/cedarsoftware/util/io/CustomReaderObjectTest.java
+++ b/src/test/java/com/cedarsoftware/util/io/CustomReaderObjectTest.java
@@ -43,11 +43,11 @@ public class CustomReaderObjectTest
 
 	public class CustomReader implements JsonReader.JsonClassReader
 	{
-		public Object read(Object jOb, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object jOb, Deque<JsonObject> stack, Map<String, Object> args)
 		{
 			ObjectResolver resolver = (ObjectResolver) args.get(JsonReader.OBJECT_RESOLVER);
-			resolver.traverseFields(stack, (JsonObject<String, Object>) jOb);
-			Object target = ((JsonObject<String, Object>) jOb).getTarget();
+            resolver.traverseFields(stack, (JsonObject) jOb);
+            Object target = ((JsonObject) jOb).getTarget();
 			madeItHere = true;
 			return target;
 		}

--- a/src/test/java/com/cedarsoftware/util/io/CustomWriterTest.java
+++ b/src/test/java/com/cedarsoftware/util/io/CustomWriterTest.java
@@ -4,7 +4,12 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -350,7 +355,7 @@ public class CustomWriterTest
 
     public static class CustomPersonReader implements JsonReader.JsonClassReader
     {
-        public Object read(Object jOb, Deque<JsonObject<String, Object>> stack, Map<String, Object> args)
+        public Object read(Object jOb, Deque<JsonObject> stack, Map<String, Object> args)
         {
             JsonReader reader = JsonReader.JsonClassReaderEx.Support.getReader(args);
             assert reader != null;

--- a/src/test/java/com/cedarsoftware/util/io/Dog.java
+++ b/src/test/java/com/cedarsoftware/util/io/Dog.java
@@ -63,8 +63,6 @@ public class Dog
         private Dog getOuterType() {
             return Dog.this;
         }
-
-
     }
 
     public static class Shoe {

--- a/src/test/java/com/cedarsoftware/util/io/InternalAPIsTest.java
+++ b/src/test/java/com/cedarsoftware/util/io/InternalAPIsTest.java
@@ -6,7 +6,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -54,8 +55,8 @@ public class InternalAPIsTest
     {
         ByteArrayOutputStream bao = new ByteArrayOutputStream();
         DerivedWriter writer = new DerivedWriter(bao);
-        Map ref = writer.getObjectsReferenced();
-        Map vis = writer.getObjectsVisited();
+        Map ref = writer.getObjsReferenced();
+        Map vis = writer.getObjVisited();
         assertNotNull(ref);
         assertNotNull(vis);
     }

--- a/src/test/java/com/cedarsoftware/util/io/LocalDateTests.java
+++ b/src/test/java/com/cedarsoftware/util/io/LocalDateTests.java
@@ -45,13 +45,13 @@ class LocalDateTests extends SerializationDeserializationMinimumTests<LocalDate>
         NestedLocalDate expectedDate = (NestedLocalDate) expected;
         NestedLocalDate actualDate = (NestedLocalDate) actual;
 
-        assertThat(actualDate.date1)
-                .isEqualTo(expectedDate.date1)
-                .isNotSameAs(actualDate.date2);
+        assertThat(actualDate.getDate1())
+                .isEqualTo(expectedDate.getDate1())
+                .isNotSameAs(actualDate.getDate2());
 
-        assertThat(actualDate.date1).isEqualTo(expectedDate.date1);
-        assertThat(actualDate.holiday).isEqualTo(expectedDate.holiday);
-        assertThat(actualDate.value).isEqualTo(expectedDate.value);
+        assertThat(actualDate.getDate1()).isEqualTo(expectedDate.getDate1());
+        assertThat(actualDate.getHoliday()).isEqualTo(expectedDate.getHoliday());
+        assertThat(actualDate.getValue()).isEqualTo(expectedDate.getValue());
     }
 
     @Override
@@ -64,13 +64,13 @@ class LocalDateTests extends SerializationDeserializationMinimumTests<LocalDate>
         NestedLocalDate expectedDate = (NestedLocalDate) expected;
         NestedLocalDate actualDate = (NestedLocalDate) actual;
 
-        assertThat(actualDate.date1)
-                .isEqualTo(expectedDate.date1)
-                .isSameAs(actualDate.date2);
+        assertThat(actualDate.getDate1())
+                .isEqualTo(expectedDate.getDate1())
+                .isSameAs(actualDate.getDate2());
 
-        assertThat(actualDate.date1).isEqualTo(expectedDate.date1);
-        assertThat(actualDate.holiday).isEqualTo(expectedDate.holiday);
-        assertThat(actualDate.value).isEqualTo(expectedDate.value);
+        assertThat(actualDate.getDate1()).isEqualTo(expectedDate.getDate1());
+        assertThat(actualDate.getHoliday()).isEqualTo(expectedDate.getHoliday());
+        assertThat(actualDate.getValue()).isEqualTo(expectedDate.getValue());
     }
 
     @Test
@@ -106,12 +106,12 @@ class LocalDateTests extends SerializationDeserializationMinimumTests<LocalDate>
         String json = loadJsonForTest("old-format-nested-level.json");
         NestedLocalDate nested = TestUtil.toJava(json);
 
-        assertThat(nested.date1)
+        assertThat(nested.getDate1())
                 .hasYear(2014)
                 .hasMonthValue(6)
                 .hasDayOfMonth(13);
 
-        assertThat(nested.date2)
+        assertThat(nested.getDate2())
                 .hasYear(2024)
                 .hasMonthValue(9)
                 .hasDayOfMonth(12);

--- a/src/test/java/com/cedarsoftware/util/io/RefsTest.java
+++ b/src/test/java/com/cedarsoftware/util/io/RefsTest.java
@@ -172,7 +172,7 @@ class RefsTest
     private static class TestObjectReader implements JsonReader.JsonClassReader {
 
         @Override
-        public Object read(Object jOb, java.util.Deque<JsonObject<String, Object>> stack, Map<String, Object> args) {
+        public Object read(Object jOb, java.util.Deque<JsonObject> stack, Map<String, Object> args) {
             var jObj = (JsonObject) jOb;
             TestObject x = new TestObject((String) jObj.get("name"));
             var b1 = (JsonObject) jObj.get("_other");

--- a/src/test/java/com/cedarsoftware/util/io/SerializedExceptionTest.java
+++ b/src/test/java/com/cedarsoftware/util/io/SerializedExceptionTest.java
@@ -51,7 +51,7 @@ public class SerializedExceptionTest
 
     public static class MyExceptionReader implements JsonReader.ClassFactory
     {
-        public Object newInstance(Class<?> c, JsonObject<String, Object> o)
+        public Object newInstance(Class<?> c, JsonObject o)
         {
             Map map = (Map) o;
             String name = (String) map.get("name");

--- a/src/test/java/com/cedarsoftware/util/io/SunMiscTest.java
+++ b/src/test/java/com/cedarsoftware/util/io/SunMiscTest.java
@@ -1,12 +1,15 @@
 package com.cedarsoftware.util.io;
 
 
+import org.junit.jupiter.api.Test;
+
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -38,7 +41,7 @@ public class SunMiscTest
         String workaroundString = TestUtil.toJson(array);
 
         JsonReader.assignInstantiator(Dog.Shoe.class, new JsonReader.ClassFactory() {
-            public Object newInstance(Class<?> c, JsonObject<String, Object> o)
+            public Object newInstance(Class<?> c, JsonObject o)
             {
                 return Dog.Shoe.construct();
             }
@@ -46,7 +49,7 @@ public class SunMiscTest
 
         Map<Class<Dog.Shoe>, JsonReader.JsonClassReader> customReader = new HashMap<Class<Dog.Shoe>, JsonReader.JsonClassReader>();
         customReader.put(Dog.Shoe.class, new JsonReader.JsonClassReader() {
-            public Object read(Object jOb, Deque<JsonObject<String, Object>> stack)
+            public Object read(Object jOb, Deque<JsonObject> stack)
             {
                 // no need to do anything special
                 return jOb;

--- a/src/test/java/com/cedarsoftware/util/io/factory/LocalDateFactoryTests.java
+++ b/src/test/java/com/cedarsoftware/util/io/factory/LocalDateFactoryTests.java
@@ -73,12 +73,12 @@ class LocalDateFactoryTests {
         String json = loadJsonForTest("old-format-nested-level.json");
         NestedLocalDate nested = TestUtil.toJava(json);
 
-        assertThat(nested.date1)
+        assertThat(nested.getDate1())
                 .hasYear(2014)
                 .hasMonthValue(6)
                 .hasDayOfMonth(13);
 
-        assertThat(nested.date2)
+        assertThat(nested.getDate2())
                 .hasYear(2024)
                 .hasMonthValue(9)
                 .hasDayOfMonth(12);

--- a/src/test/java/com/cedarsoftware/util/io/factory/ZonedDateTimeFactoryTests.java
+++ b/src/test/java/com/cedarsoftware/util/io/factory/ZonedDateTimeFactoryTests.java
@@ -89,12 +89,12 @@ class ZonedDateTimeFactoryTests {
         return TestUtil.fetchResource("zoneddatetime/" + fileName);
     }
 
-    private JsonObject<String, Object> buildJsonObject(String localDateTime, String zoneId, Number totalSeconds) {
-        var jsonObject = new JsonObject<String, Object>();
-        var zone = new JsonObject<String, Object>();
+    private JsonObject buildJsonObject(String localDateTime, String zoneId, Number totalSeconds) {
+        var jsonObject = new JsonObject();
+        var zone = new JsonObject();
         zone.put("id", zoneId);
 
-        var offset = new JsonObject<String, Object>();
+        var offset = new JsonObject();
         offset.put("totalSeconds", totalSeconds == null ? 0 : totalSeconds.intValue());
 
         jsonObject.put("dateTime", localDateTime);
@@ -103,8 +103,8 @@ class ZonedDateTimeFactoryTests {
         return jsonObject;
     }
 
-    private JsonObject<String, Object> buildJsonObject(String zonedDateTime) {
-        var jsonObject = new JsonObject<String, Object>();
+    private JsonObject buildJsonObject(String zonedDateTime) {
+        var jsonObject = new JsonObject();
         jsonObject.put("value", zonedDateTime);
         return jsonObject;
     }

--- a/src/test/java/com/cedarsoftware/util/io/models/NestedLocalDate.java
+++ b/src/test/java/com/cedarsoftware/util/io/models/NestedLocalDate.java
@@ -1,12 +1,15 @@
 package com.cedarsoftware.util.io.models;
 
+import lombok.Getter;
+
 import java.time.LocalDate;
 
+@Getter
 public class NestedLocalDate {
-    public LocalDate date1;
-    public LocalDate date2;
-    public String holiday;
-    public Long value;
+    private final LocalDate date1;
+    private final LocalDate date2;
+    private final String holiday;
+    private final Long value;
 
     public NestedLocalDate(LocalDate date1, LocalDate date2) {
         this.holiday = "Festivus";


### PR DESCRIPTION
Added Lombok as compile time dependency
Remove extra generic type on JsonObject itself (We can still move this back to <String, Object> when we make changes to the resolving to not use JsonObjects throughout.
Added some example lombok @Getter, @Setter, and @AllArgumentsConstructor 