### PR TITLE
Situation that cannot be serialized, but should be

### DIFF
--- a/src/test/java/com/cedarsoftware/util/io/FieldsTest.java
+++ b/src/test/java/com/cedarsoftware/util/io/FieldsTest.java
@@ -1,14 +1,26 @@
 package com.cedarsoftware.util.io;
 
 import com.cedarsoftware.util.DeepEquals;
+import com.cedarsoftware.util.io.models.OuterObject;
 import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -29,6 +41,18 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class FieldsTest
 {
+    @Test
+    void testNestedPrivateClass() {
+        var expected = OuterObject.of(9, 12, "Happy Holidays", "Some Other Message");
+        String json = TestUtil.toJson(expected);
+        TestUtil.printLine(json);
+        OuterObject actual = TestUtil.toJava(json);
+        assertThat(actual.getX()).isEqualTo(expected.getX());
+        assertThat(actual.getY()).isEqualTo(expected.getY());
+        assertThat(actual.getMessage1Holder().getMessage()).isEqualTo(expected.getMessage1Holder().getMessage());
+        assertThat(actual.getMessage2Holder().getMessage()).isEqualTo(expected.getMessage2Holder().getMessage());
+    }
+
     @Test
     public void testFields()
     {

--- a/src/test/java/com/cedarsoftware/util/io/models/MessageHolder.java
+++ b/src/test/java/com/cedarsoftware/util/io/models/MessageHolder.java
@@ -1,0 +1,5 @@
+package com.cedarsoftware.util.io.models;
+
+public interface MessageHolder {
+    public String getMessage();
+}

--- a/src/test/java/com/cedarsoftware/util/io/models/MessageTwoHolder.java
+++ b/src/test/java/com/cedarsoftware/util/io/models/MessageTwoHolder.java
@@ -1,0 +1,10 @@
+package com.cedarsoftware.util.io.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+class MessageTwoHolder implements MessageHolder {
+    String message;
+}

--- a/src/test/java/com/cedarsoftware/util/io/models/OuterObject.java
+++ b/src/test/java/com/cedarsoftware/util/io/models/OuterObject.java
@@ -1,0 +1,32 @@
+package com.cedarsoftware.util.io.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+@Getter
+public class OuterObject {
+
+    private int x;
+    private int y;
+
+    private MessageHolder message1Holder;
+
+    private MessageHolder message2Holder;
+
+
+    public static OuterObject of(int x, int y, String message1, String message2) {
+        var object = new OuterObject();
+        object.x = x;
+        object.y = y;
+        object.message1Holder = new MessageOneHolder(message1);
+        object.message2Holder = new MessageTwoHolder(message2);
+        return object;
+    }
+
+    @AllArgsConstructor
+    @Getter
+    private static class MessageOneHolder implements MessageHolder {
+        public String message;
+    }
+}


### PR DESCRIPTION
Most of current tests were in the same package as our parsers.  There are cases where data is intentionally protected from the outside (Such as class being private, but it implements and interface of public getters).  We currently cannot recreate these classes when the class itself is not public.\

This can be fixed by changing the logic on the field to also check to see if the class is not public and setting the field to being accessible in those cases.  We'll have to discuss what we will allow in the future, but for now this will give us the maximum serialization / deserialization capabilities.

`        if (!(Modifier.isPublic(f.getModifiers()) && Modifier.isPublic(f.getDeclaringClass().getModifiers()))) {
            f.trySetAccessible();
        }
`