### PR TITLE
Changed stackTrace on Throwable to be filtered by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,7 +345,7 @@
             <scope>test</scope>
         </dependency>
 
-<!-- Attempting to get the Surefire Logger, so tests can write to it, and then SL4FJ and Logback are not needed -->
+        <!-- Attempting to get the Surefire Logger, so tests can write to it, and then SL4FJ and Logback are not needed -->
 <!--        <dependency>-->
 <!--            <groupId>org.apache.maven.surefire</groupId>-->
 <!--            <artifactId>surefire-api</artifactId>-->

--- a/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
+++ b/src/main/java/com/cedarsoftware/util/io/MetaUtils.java
@@ -20,7 +20,26 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TimeZone;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -1220,25 +1239,39 @@ public class MetaUtils
 
     public static boolean trySetAccessible(Field field)
     {
-        try
-        {
+        return safelyIgnoreException(() -> {
             field.setAccessible(true);
             return true;
-        }
-        catch (Exception ignore)
-        {
-            return false;
-        }
+        }, false);
     }
 
     public static boolean trySetAccessible(Method method) {
-        try {
+        return safelyIgnoreException(() -> {
             method.setAccessible(true);
             return true;
-        } catch (Exception ignore) {
-            return false;
+        }, false);
+//
+//        try {
+//            method.setAccessible(true);
+//            return true;
+//        } catch (Exception ignore) {
+//            return false;
+//        }
+    }
+
+
+    public interface Callable<V> {
+        V call() throws Throwable;
+    }
+
+    public static <T> T safelyIgnoreException(Callable<T> callable, T defaultValue) {
+        try {
+            return callable.call();
+        } catch (Throwable e) {
+            return defaultValue;
         }
     }
+
 
     /**
      * Wrapper for unsafe, decouples direct usage of sun.misc.* package.

--- a/src/main/java/com/cedarsoftware/util/io/ReadOptionsBuilder.java
+++ b/src/main/java/com/cedarsoftware/util/io/ReadOptionsBuilder.java
@@ -3,6 +3,7 @@ package com.cedarsoftware.util.io;
 import com.cedarsoftware.util.io.factory.LocalDateFactory;
 import com.cedarsoftware.util.io.factory.LocalDateTimeFactory;
 import com.cedarsoftware.util.io.factory.LocalTimeFactory;
+import com.cedarsoftware.util.io.factory.StackTraceElementFactory;
 import com.cedarsoftware.util.io.factory.ThrowableFactory;
 import com.cedarsoftware.util.io.factory.TimeZoneFactory;
 import com.cedarsoftware.util.io.factory.ZonedDateTimeFactory;
@@ -116,6 +117,7 @@ public class ReadOptionsBuilder {
         assignInstantiator(Throwable.class, throwableFactory);
         assignInstantiator(Exception.class, throwableFactory);
         assignInstantiator(RuntimeException.class, throwableFactory);
+        assignInstantiator(StackTraceElement.class, new StackTraceElementFactory());
 
         //  Readers
         addReaderPermanent(String.class, new Readers.StringReader());

--- a/src/main/java/com/cedarsoftware/util/io/WriteOptionsBuilder.java
+++ b/src/main/java/com/cedarsoftware/util/io/WriteOptionsBuilder.java
@@ -1,6 +1,7 @@
 package com.cedarsoftware.util.io;
 
 import com.cedarsoftware.util.reflect.Accessor;
+import com.cedarsoftware.util.reflect.KnownFilteredFields;
 import lombok.Getter;
 
 import java.math.BigDecimal;
@@ -12,13 +13,35 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.cedarsoftware.util.io.ArgumentHelper.isTrue;
-import static com.cedarsoftware.util.io.JsonWriter.*;
+import static com.cedarsoftware.util.io.JsonWriter.CLASSLOADER;
+import static com.cedarsoftware.util.io.JsonWriter.CUSTOM_WRITER_MAP;
+import static com.cedarsoftware.util.io.JsonWriter.ENUM_PUBLIC_ONLY;
+import static com.cedarsoftware.util.io.JsonWriter.FIELD_NAME_BLACK_LIST;
+import static com.cedarsoftware.util.io.JsonWriter.FIELD_SPECIFIERS;
+import static com.cedarsoftware.util.io.JsonWriter.FORCE_MAP_FORMAT_ARRAY_KEYS_ITEMS;
+import static com.cedarsoftware.util.io.JsonWriter.NOT_CUSTOM_WRITER_MAP;
+import static com.cedarsoftware.util.io.JsonWriter.PRETTY_PRINT;
+import static com.cedarsoftware.util.io.JsonWriter.SHORT_META_KEYS;
+import static com.cedarsoftware.util.io.JsonWriter.SKIP_NULL_FIELDS;
+import static com.cedarsoftware.util.io.JsonWriter.TYPE;
+import static com.cedarsoftware.util.io.JsonWriter.TYPE_NAME_MAP;
+import static com.cedarsoftware.util.io.JsonWriter.WRITE_LONGS_AS_STRINGS;
 
 /**
  * @author Kenny Partlow (kpartlow@gmail.com)
@@ -47,7 +70,6 @@ public class WriteOptionsBuilder {
 
     private final Map<Class<?>, Collection<String>> fieldSpecifiers = new HashMap<>();
 
-
     static {
         Map<Class<?>, JsonWriter.JsonClassWriter> temp = new HashMap<>();
         temp.put(String.class, new Writers.JsonStringWriter());
@@ -71,7 +93,6 @@ public class WriteOptionsBuilder {
         temp.put(LocalTime.class, new Writers.LocalTimeWriter());
         temp.put(LocalDateTime.class, new Writers.LocalDateTimeWriter());
         temp.put(ZonedDateTime.class, new Writers.ZonedDateTimeWriter());
-        //temp.put(Throwable.class, new Writers.ThrowableWriter());
 
         Class<?> zoneInfoClass = MetaUtils.classForName("sun.util.calendar.ZoneInfo", WriteOptions.class.getClassLoader());
         if (zoneInfoClass != null)
@@ -193,6 +214,11 @@ public class WriteOptionsBuilder {
     public WriteOptionsBuilder showMinimalTypeInfo() {
         this.writeOptions.alwaysShowingType = false;
         this.writeOptions.neverShowingType = false;
+        return this;
+    }
+
+    public WriteOptionsBuilder sendStackTraceWithExceptions() {
+        KnownFilteredFields.instance().removeMapping(Throwable.class, "stackTrace");
         return this;
     }
 
@@ -388,7 +414,6 @@ public class WriteOptionsBuilder {
     }
 
     public WriteOptions build() {
-
         this.writeOptions.fieldSpecifiers.putAll(MetaUtils.convertStringFieldNamesToAccessors(this.fieldSpecifiers));
         this.writeOptions.fieldNameBlackList.putAll(MetaUtils.convertStringFieldNamesToAccessors(this.fieldNameBlackList));
         return writeOptions;

--- a/src/main/java/com/cedarsoftware/util/io/factory/StackTraceElementFactory.java
+++ b/src/main/java/com/cedarsoftware/util/io/factory/StackTraceElementFactory.java
@@ -1,0 +1,80 @@
+package com.cedarsoftware.util.io.factory;
+
+import com.cedarsoftware.util.io.JsonObject;
+import com.cedarsoftware.util.io.JsonReader;
+import com.cedarsoftware.util.io.MetaUtils;
+
+import java.lang.reflect.Constructor;
+
+/**
+ * Factory class to create Throwable instances.  Needed for JDK17+ as the only way to set the
+ * 'detailMessage' field on a Throwable is via its constructor.
+ * <p>
+ *
+ * @author Ken Partlow (kpartlow@gmail.com)
+ * <br>
+ * Copyright (c) Cedar Software LLC
+ * <br><br>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <br><br>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <br><br>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class StackTraceElementFactory implements JsonReader.ClassFactory {
+
+    public static final String DECLARING_CLASS = "declaringClass";
+    public static final String METHOD_NAME = "methodName";
+    public static final String FILE_NAME = "fileName";
+    public static final String LINE_NUMBER = "lineNumber";
+    public static final String CLASS_LOADER_NAME = "classLoaderName";
+    public static final String MODULE_NAME = "moduleName";
+    public static final String MODULE_VERSION = "moduleVersion";
+
+    private static Constructor<?> constructor1;
+
+    private static Constructor<?> constructor2;
+
+    static {
+        constructor1 = MetaUtils.safelyIgnoreException(() -> StackTraceElement.class.getConstructor(String.class, String.class, String.class, int.class), null);
+        constructor2 = MetaUtils.safelyIgnoreException(() -> StackTraceElement.class.getConstructor(String.class, String.class, String.class, String.class, String.class, String.class, int.class), null);
+    }
+
+    public Object newInstance(Class<?> c, JsonObject jsonObj) {
+        String declaringClass = (String) jsonObj.get(DECLARING_CLASS);
+        String methodName = (String) jsonObj.get(METHOD_NAME);
+        String fileName = (String) jsonObj.get(FILE_NAME);
+        Number lineNumber = (Number) jsonObj.get(LINE_NUMBER);
+
+        String classLoaderName = (String) jsonObj.get(CLASS_LOADER_NAME);
+        String moduleName = (String) jsonObj.get(MODULE_NAME);
+        String moduleVersion = (String) jsonObj.get(MODULE_VERSION);
+
+        if (constructor2 != null) {
+            StackTraceElement element = MetaUtils.safelyIgnoreException(() -> (StackTraceElement) constructor2.newInstance(classLoaderName, moduleName, moduleVersion, declaringClass, methodName, fileName, lineNumber.intValue()), null);
+            if (element != null) {
+                return element;
+            }
+        }
+
+        if (constructor1 != null) {
+            StackTraceElement element = MetaUtils.safelyIgnoreException(() -> (StackTraceElement) constructor1.newInstance(declaringClass, methodName, fileName, lineNumber.intValue()), null);
+            if (element != null) {
+                return element;
+            }
+        }
+
+        //  if the elements failed using reflection do the old version directly.
+        return new StackTraceElement(declaringClass, methodName, fileName, lineNumber.intValue());
+    }
+
+    public boolean isObjectFinal() {
+        return true;
+    }
+}

--- a/src/main/java/com/cedarsoftware/util/io/factory/ThrowableFactory.java
+++ b/src/main/java/com/cedarsoftware/util/io/factory/ThrowableFactory.java
@@ -45,7 +45,7 @@ public class ThrowableFactory implements JsonReader.ClassFactory
         Throwable t = createException(c, msg, cause);
 
         Object[] stackTraces = (Object[]) jsonObj.get(STACK_TRACE);
-        if (stackTraces != null) {
+        if (stackTraces != null && stackTraces.length > 0) {
             StackTraceElement[] elements = new StackTraceElement[stackTraces.length];
 
             for (int i = 0; i < stackTraces.length; i++) {
@@ -92,7 +92,7 @@ public class ThrowableFactory implements JsonReader.ClassFactory
             throw new JsonIoException("Error instantiating constructor: " + type.getName(), e);
         }
 
-        throw new JsonIoException("Unable to find one of the four Throwable.class constructors on Class: " + type.getName());
+        throw new JsonIoException("Unable to find one of the four Throwable.class constructors on Class: " + type.getName() + ". Either implement your own writer or add one of the superclass constructors.");
     }
 
     public boolean isObjectFinal()

--- a/src/main/java/com/cedarsoftware/util/reflect/ClassDescriptors.java
+++ b/src/main/java/com/cedarsoftware/util/reflect/ClassDescriptors.java
@@ -6,8 +6,8 @@ import com.cedarsoftware.util.reflect.factories.EnumNameAccessorFactory;
 import com.cedarsoftware.util.reflect.factories.MappedMethodAccessorFactory;
 import com.cedarsoftware.util.reflect.filters.EnumFilter;
 import com.cedarsoftware.util.reflect.filters.GroovyFilter;
-import com.cedarsoftware.util.reflect.filters.KnownFilteredFields;
 import com.cedarsoftware.util.reflect.filters.StaticFilter;
+import lombok.Getter;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -73,6 +73,10 @@ public class ClassDescriptors {
         return this.descriptors.computeIfAbsent(c, this::buildDescriptor);
     }
 
+    void clearDescriptorCache() {
+        this.descriptors.clear();
+    }
+
     private ClassDescriptor buildDescriptor(Class<?> c) {
         final Map<String, Method> possibleAccessors = ReflectionUtils.buildAccessorMap(c);
         final Map<String, Method> possibleInjectors = ReflectionUtils.buildInjectorMap(c);
@@ -100,16 +104,20 @@ public class ClassDescriptors {
     }
 
     public boolean addFilter(FieldFilter filter) {
+        clearDescriptorCache();
         return this.fieldFilters.add(filter);
     }
 
     public boolean removeFilter(FieldFilter filter) {
+        clearDescriptorCache();
         return this.fieldFilters.remove(filter);
     }
 
     public class ClassDescriptorImpl implements ClassDescriptor {
 
+        @Getter
         private final Map<String, Accessor> accessors;
+        @Getter
         private final Map<String, Injector> injectors;
         private final Class describedClass;
 
@@ -126,15 +134,5 @@ public class ClassDescriptors {
         public void addInjector(String name, Injector injector) {
             this.injectors.put(name, injector);
         }
-
-        public Map<String, Accessor> getAccessors() {
-            return this.accessors;
-        }
-
-        public Map<String, Injector> getInjectors() {
-            return this.injectors;
-        }
-
-
     }
 }

--- a/src/main/java/com/cedarsoftware/util/reflect/KnownFilteredFields.java
+++ b/src/main/java/com/cedarsoftware/util/reflect/KnownFilteredFields.java
@@ -1,4 +1,4 @@
-package com.cedarsoftware.util.reflect.filters;
+package com.cedarsoftware.util.reflect;
 
 import com.cedarsoftware.util.io.MetaUtils;
 
@@ -23,16 +23,23 @@ public class KnownFilteredFields {
     }
 
     private void addKnownFilters() {
-        addMapping(Throwable.class, MetaUtils.listOf("backtrace", "depth", "suppressedExceptions"));
-        addMapping(StackTraceElement.class, MetaUtils.listOf("declaringClassObject", "format"));
+        addMappings(Throwable.class, MetaUtils.listOf("backtrace", "depth", "suppressedExceptions", "stackTrace"));
+        addMappings(StackTraceElement.class, MetaUtils.listOf("declaringClassObject", "format"));
     }
 
     public void addMapping(Class c, String fieldName) {
         this.classToMapping.computeIfAbsent(c, k -> new ConcurrentSkipListSet<>()).add(fieldName);
+        ClassDescriptors.instance().clearDescriptorCache();
     }
 
-    public void addMapping(Class c, Collection<String> fieldName) {
+    public void addMappings(Class c, Collection<String> fieldName) {
         this.classToMapping.computeIfAbsent(c, k -> new ConcurrentSkipListSet<>()).addAll(fieldName);
+        ClassDescriptors.instance().clearDescriptorCache();
+    }
+
+    public void removeMapping(Class c, String fieldName) {
+        this.classToMapping.computeIfAbsent(c, k -> new ConcurrentSkipListSet<>()).remove(fieldName);
+        ClassDescriptors.instance().clearDescriptorCache();
     }
 
     public boolean contains(Field field) {

--- a/src/test/java/com/cedarsoftware/util/io/factory/StackTraceElementFactoryTest.java
+++ b/src/test/java/com/cedarsoftware/util/io/factory/StackTraceElementFactoryTest.java
@@ -1,0 +1,51 @@
+package com.cedarsoftware.util.io.factory;
+
+import com.cedarsoftware.util.io.JsonObject;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StackTraceElementFactoryTest {
+
+    private static Stream<Arguments> variants() {
+        return Stream.of(
+                Arguments.of("app", null, null, "declaringClass", "methodName", "fileName", 239L),
+                Arguments.of(null, "module", "version", "declaringClass", "methodName", "fileName", 239L),
+                Arguments.of(null, null, null, "declaringClass", "methodName", "fileName", -1L)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("variants")
+    void newInstance_testVariants(String classLoaderName, String moduleName, String moduleVersion, String declaringClass, String methodName, String fileName, Long lineNumber) {
+        StackTraceElementFactory factory = new StackTraceElementFactory();
+        JsonObject jsonObject = buildJsonObject(classLoaderName, moduleName, moduleVersion, declaringClass, methodName, fileName, lineNumber);
+
+        StackTraceElement stackTrace = (StackTraceElement) factory.newInstance(StackTraceElement.class, jsonObject);
+
+        assertThat(stackTrace.getClassName()).isEqualTo(declaringClass);
+        assertThat(stackTrace.getMethodName()).isEqualTo(methodName);
+        assertThat(stackTrace.getFileName()).isEqualTo(fileName);
+        assertThat(stackTrace.getLineNumber()).isEqualTo(lineNumber.intValue());
+        //assertThat(stackTrace.getModuleName()).isEqualTo(moduleName);
+        //assertThat(stackTrace.getModuleVersion()).isEqualTo(moduleVersion);
+        //assertThat(stackTrace.getClassLoaderName()).isEqualTo(classLoaderName);
+    }
+
+    private JsonObject buildJsonObject(String classLoaderName, String moduleName, String moduleVersion, String declaringClass, String methodName, String fileName, Long lineNumber) {
+        JsonObject object = new JsonObject();
+
+        object.put("declaringClass", declaringClass);
+        object.put("methodName", methodName);
+        object.put("fileName", fileName);
+        object.put("lineNumber", lineNumber);
+        object.put("classLoaderName", classLoaderName);
+        object.put("moduleName", moduleName);
+        object.put("moduleVersion", moduleVersion);
+        return object;
+    }
+}

--- a/src/test/java/com/cedarsoftware/util/reflect/filters/KnownFilteredFieldsTest.java
+++ b/src/test/java/com/cedarsoftware/util/reflect/filters/KnownFilteredFieldsTest.java
@@ -1,0 +1,87 @@
+package com.cedarsoftware.util.reflect.filters;
+
+import com.cedarsoftware.util.io.MetaUtils;
+import com.cedarsoftware.util.reflect.KnownFilteredFields;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KnownFilteredFieldsTest {
+
+    private List<Field> getFields(Class c, Set<String> set) {
+        Field[] fields = c.getDeclaredFields();
+        return Arrays.stream(fields).filter(f -> set.contains(f.getName())).collect(Collectors.toList());
+    }
+
+    private static Stream<Arguments> filteredFields() {
+        return Stream.of(
+                Arguments.of(Throwable.class, new String[]{"backtrace", "depth", "suppressedExceptions", "stackTrace"}),
+                Arguments.of(StackTraceElement.class, new String[]{"declaringClassObject", "format"})
+        );
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        KnownFilteredFields.instance().addMapping(Throwable.class, "stackTrace");
+        KnownFilteredFields.instance().removeMapping(Throwable.class, "detailMessage");
+    }
+
+    @ParameterizedTest
+    @MethodSource("filteredFields")
+    void testContains_fieldsThatShouldBeFiltered(Class c, String... fieldNames) {
+        Set set = MetaUtils.setOf(fieldNames);
+        List<Field> fields = getFields(c, set);
+
+        assertThat(fields.size()).isEqualTo(fieldNames.length);
+
+        KnownFilteredFields knownFilteredFields = KnownFilteredFields.instance();
+
+        for (Field f : fields) {
+            assertThat(knownFilteredFields.contains(f)).isTrue();
+        }
+    }
+
+    @Test
+    void testAddMapping() {
+        KnownFilteredFields knownFilteredFields = KnownFilteredFields.instance();
+        List<Field> fields = getFields(Throwable.class, MetaUtils.setOf("detailMessage"));
+        assertThat(knownFilteredFields.contains(fields.get(0))).isFalse();
+
+        knownFilteredFields.addMapping(Throwable.class, "detailMessage");
+        assertThat(knownFilteredFields.contains(fields.get(0))).isTrue();
+    }
+
+    @Test
+    void testAddMappings() {
+        KnownFilteredFields knownFilteredFields = KnownFilteredFields.instance();
+        List<Field> fields = getFields(Throwable.class, MetaUtils.setOf("detailMessage", "cause"));
+        assertThat(knownFilteredFields.contains(fields.get(0))).isFalse();
+        assertThat(knownFilteredFields.contains(fields.get(1))).isFalse();
+
+        knownFilteredFields.addMappings(Throwable.class, MetaUtils.listOf("detailMessage", "cause"));
+        assertThat(knownFilteredFields.contains(fields.get(0))).isTrue();
+        assertThat(knownFilteredFields.contains(fields.get(1))).isTrue();
+    }
+
+    @Test
+    void testRemoveMapping() {
+        KnownFilteredFields knownFilteredFields = KnownFilteredFields.instance();
+        List<Field> fields = getFields(Throwable.class, MetaUtils.setOf("stackTrace"));
+        assertThat(knownFilteredFields.contains(fields.get(0))).isTrue();
+
+        knownFilteredFields.removeMapping(Throwable.class, "stackTrace");
+        assertThat(knownFilteredFields.contains(fields.get(0))).isFalse();
+    }
+
+}


### PR DESCRIPTION
Made stack trace Serialization configurable with WriteOption
Adjust Java 17+ (setters were removed so had to create via constructor)
Added MetaUtils.safelyIgnoreException for readabiilty on exceptions that are expected to be ignored.