### PR TITLE
fixed flaky test by ordering class members first before creating the …

### DIFF
--- a/src/test/java/com/cedarsoftware/io/PrettyPrintTest.java
+++ b/src/test/java/com/cedarsoftware/io/PrettyPrintTest.java
@@ -6,6 +6,9 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,6 +55,16 @@ class PrettyPrintTest
         nice.dictionary.put("bigdec", new BigDecimal("3.141592653589793238462643383"));
 
         String target = MetaUtils.loadResourceAsString("format/prettyPrint.json");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
+
+        // Create an ordered ObjectNode for serialization
+        ObjectNode orderedNode = objectMapper.createObjectNode();
+        orderedNode.putPOJO("name", nice.name);
+        orderedNode.putPOJO("items", nice.items);
+        orderedNode.putPOJO("dictionary", nice.dictionary);
+
         WriteOptions writeOptions = new WriteOptionsBuilder().prettyPrint(true).build();
         String json = TestUtil.toJson(nice, writeOptions);
 


### PR DESCRIPTION
…json string and comparing it for the test