### PR TITLE
feat: deserialize all non-static fields

### DIFF
--- a/src/main/java/com/cedarsoftware/io/ReadOptionsBuilder.java
+++ b/src/main/java/com/cedarsoftware/io/ReadOptionsBuilder.java
@@ -1223,6 +1223,8 @@ public class ReadOptionsBuilder {
 
                     if (map.putIfAbsent(name, field) != null) {
                         map.put(field.getDeclaringClass().getSimpleName() + '.' + name, field);
+                        // to support inner classes that were serialized by previous version of json-io
+                        map.put(field.getDeclaringClass().getName() + '.' + name, field);
                     }
                 }
                 curr = curr.getSuperclass();

--- a/src/main/java/com/cedarsoftware/io/reflect/Injector.java
+++ b/src/main/java/com/cedarsoftware/io/reflect/Injector.java
@@ -1,5 +1,7 @@
 package com.cedarsoftware.io.reflect;
 
+import static java.lang.reflect.Modifier.isPublic;
+
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -9,8 +11,6 @@ import java.lang.reflect.Type;
 import com.cedarsoftware.io.JsonIoException;
 import com.cedarsoftware.util.Converter;
 import com.cedarsoftware.util.StringUtilities;
-
-import static java.lang.reflect.Modifier.isPublic;
 
 /**
  * @author Ken Partlow (kpartlow@gmail.com)
@@ -67,6 +67,7 @@ public class Injector {
     }
 
     public static Injector create(Field field, String methodName, String uniqueFieldName) {
+        // find method that returns void
         try {
             MethodType methodType = MethodType.methodType(Void.class, field.getType());
             MethodHandle handle = MethodHandles.publicLookup().findVirtual(field.getDeclaringClass(), methodName, methodType);
@@ -84,8 +85,7 @@ public class Injector {
 
         try {
             injector.invoke(object, value);
-        }
-        catch (ClassCastException e) {
+        } catch (ClassCastException e) {
             String msg = e.getMessage();
             if (StringUtilities.hasContent(msg) && msg.contains("LinkedHashMap")) {
                 throw new JsonIoException("Unable to set field: " + getName() + " using " + getDisplayName() + ".", e);
@@ -95,8 +95,7 @@ public class Injector {
             } catch (Throwable t) {
                 throw new JsonIoException("Unable to set field: " + getName() + " using " + getDisplayName() + ". Getting a ClassCastException.", e);
             }
-        }
-        catch (Throwable t) {
+        } catch (Throwable t) {
             if (t instanceof JsonIoException) {
                 throw (JsonIoException) t;
             }

--- a/src/main/java/com/cedarsoftware/io/reflect/factories/AllowAllNonStaticFieldMethodInjectorFactory.java
+++ b/src/main/java/com/cedarsoftware/io/reflect/factories/AllowAllNonStaticFieldMethodInjectorFactory.java
@@ -1,0 +1,23 @@
+package com.cedarsoftware.io.reflect.factories;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Map;
+
+import com.cedarsoftware.io.reflect.Injector;
+import com.cedarsoftware.io.reflect.InjectorFactory;
+
+public class AllowAllNonStaticFieldMethodInjectorFactory implements InjectorFactory {
+
+    @Override
+    public Injector createInjector(final Field field,
+                                   final Map<Class<?>, Map<String, String>> nonStandardNames,
+                                   final String uniqueName) {
+        if (!Modifier.isStatic(field.getModifiers()) && !field.isAccessible()) {
+            // it makes Lookup to be changed to trusted during the unreflectField
+            field.setAccessible(true);
+        }
+
+        return Injector.create(field, uniqueName);
+    }
+}

--- a/src/test/java/com/cedarsoftware/io/FinalFieldsTest.java
+++ b/src/test/java/com/cedarsoftware/io/FinalFieldsTest.java
@@ -39,8 +39,8 @@ class FinalFieldsTest {
         public final ComplexObject _object = ComplexObject.newDefaultObject();
 
         private FinalFieldsIncluded(final char charFinalA, final String stringFinalA) {
-            _charFinalA = charFinalA;
-            _stringFinalA = stringFinalA;
+            this._charFinalA = charFinalA;
+            this._stringFinalA = stringFinalA;
         }
 
         public static FinalFieldsIncluded newDefaultObject() {
@@ -55,7 +55,7 @@ class FinalFieldsTest {
         public String _stringB;
 
         private ComplexObject(final String stringFinalA) {
-            _stringFinalA = stringFinalA;
+            this._stringFinalA = stringFinalA;
         }
 
         public static ComplexObject newDefaultObject() {

--- a/src/test/java/com/cedarsoftware/io/FinalFieldsTest.java
+++ b/src/test/java/com/cedarsoftware/io/FinalFieldsTest.java
@@ -1,0 +1,67 @@
+package com.cedarsoftware.io;
+
+import java.io.Serializable;
+
+import com.cedarsoftware.io.reflect.factories.AllowAllNonStaticFieldMethodInjectorFactory;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class FinalFieldsTest {
+
+    @Test
+    void testFields() {
+        final FinalFieldsIncluded expected = FinalFieldsIncluded.newDefaultObject();
+        // we can see that it wasn't really deserialized by changed fields inside final fields
+        expected._object._stringB = "Vasyl Stus";
+
+        String jsonOut = TestUtil.toJson(expected);
+        TestUtil.printLine(jsonOut);
+
+        FinalFieldsIncluded actual = TestUtil.toObjects(jsonOut, new ReadOptionsBuilder()
+                .addInjectorFactory(new AllowAllNonStaticFieldMethodInjectorFactory())
+                .build(), null);
+
+        Assertions.assertEquals(expected._charFinalA, actual._charFinalA);
+        Assertions.assertEquals(expected._stringFinalA, actual._stringFinalA);
+        Assertions.assertEquals(expected._stringB, actual._stringB);
+
+        Assertions.assertNotSame(expected._object, actual._object);
+        Assertions.assertEquals(expected._object._stringFinalA, actual._object._stringFinalA);
+        Assertions.assertEquals(expected._object._stringB, actual._object._stringB);
+    }
+
+    // it's important that the modifier is public
+    public static class FinalFieldsIncluded implements Serializable {
+        public final char _charFinalA;
+        public final String _stringFinalA;
+        public String _stringB;
+        public final ComplexObject _object = ComplexObject.newDefaultObject();
+
+        private FinalFieldsIncluded(final char charFinalA, final String stringFinalA) {
+            _charFinalA = charFinalA;
+            _stringFinalA = stringFinalA;
+        }
+
+        public static FinalFieldsIncluded newDefaultObject() {
+            final FinalFieldsIncluded object = new FinalFieldsIncluded('b', "Lesia Ukrainka");
+            object._stringB = "Ivan Franko";
+            return object;
+        }
+    }
+
+    public static class ComplexObject implements Serializable {
+        public final String _stringFinalA;
+        public String _stringB;
+
+        private ComplexObject(final String stringFinalA) {
+            _stringFinalA = stringFinalA;
+        }
+
+        public static ComplexObject newDefaultObject() {
+            final ComplexObject object = new ComplexObject("William Shakespeare");
+            object._stringB = "Taras Shevchenko";
+            return object;
+        }
+    }
+}

--- a/src/test/java/com/cedarsoftware/io/OldParentChildTest.java
+++ b/src/test/java/com/cedarsoftware/io/OldParentChildTest.java
@@ -1,0 +1,39 @@
+package com.cedarsoftware.io;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class OldParentChildTest {
+
+    @Test
+    void chainedSetterUsedCorrectly() {
+        String json = "{\"@type\":\"com.cedarsoftware.io.OldParentChildTest$Child\",\"name\":42,\"com.cedarsoftware.io.OldParentChildTest$Parent.name\":\"Stus\"}";
+
+        Child actual = TestUtil.toObjects(json, null);
+
+        Assertions.assertEquals(42L, actual.name);
+        Assertions.assertEquals("Stus", actual.getName());
+    }
+
+    public static class Parent {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public Parent setName(final String name) {
+            this.name = name;
+            return this;
+        }
+    }
+
+    public static class Child extends Parent {
+        public Long name;
+
+        public Child(final Long name, final String surname) {
+            super.setName(surname);
+            this.name = name;
+        }
+    }
+}


### PR DESCRIPTION
Add injector that can help with #287

@jdereg This PRs add the injector that the user can add by request, or we can make it by default
I didn't do it in case if someone doesn't want to deserialize inside the final fields
But frankly, it makes small sense, because as far as I can see in that situation those fields might be broken.
if they were initialized by constructor

----
I want to consult with you, but I think we should just change the implementation of 
com.cedarsoftware.io.reflect.Injector#create(java.lang.reflect.Field, java.lang.String)
and setAccessible almost always if it wasn't set