### PR TITLE
Test Fix: Fix a test that can unintentionally fail in testAssignAtomicInteger()

### DIFF
--- a/src/test/java/com/cedarsoftware/io/AtomicIntegerTest.java
+++ b/src/test/java/com/cedarsoftware/io/AtomicIntegerTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import com.google.gson.JsonParser;
+
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
  *         <br>
@@ -57,7 +59,10 @@ class AtomicIntegerTest
         assert atom2.values[3].get() == 45;
 
         json = TestUtil.toJson(atom2);
-        assert json.equals("{\"@type\":\"com.cedarsoftware.io.AtomicIntegerTest$TestAtomicIntegerField\",\"value\":16,\"nullValue\":null,\"strValue\":50,\"emptyStrValue\":0,\"objValue\":-9,\"values\":[-5,null,5,45]}");
+        
+        String expectedJson = "{\"@type\":\"com.cedarsoftware.io.AtomicIntegerTest$TestAtomicIntegerField\",\"value\":16,\"nullValue\":null,\"strValue\":50,\"emptyStrValue\":0,\"objValue\":-9,\"values\":[-5,null,5,45]}";
+
+        assert JsonParser.parseString(json).equals(JsonParser.parseString(expectedJson));
         
         json = "{\"@type\":\"com.cedarsoftware.io.AtomicIntegerTest$TestAtomicIntegerField\",\"value\":16.5}";
         TestAtomicIntegerField aif = TestUtil.toObjects(json, null);


### PR DESCRIPTION
Due to TestUtil.toJson(), the json string may not be in a consistent order when converting an object into a JSON string. This could result in an AssertionError when comparing the converted JSON with the expected JSON. Below is an example where it fails under NonDex on [line 60](https://github.com/jdereg/json-io/blob/47fe31aa3996fff6963fcf7ce65dcf2eb46dbb09/src/test/java/com/cedarsoftware/io/AtomicIntegerTest.java#L60)

<details>

<summary>Click on to see more details on the error message when running this flaky test</summary>

```
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.cedarsoftware.io.AtomicIntegerTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.698 s <<< FAILURE! -- in com.cedarsoftware.io.AtomicIntegerTest
[ERROR] com.cedarsoftware.io.AtomicIntegerTest.testAssignAtomicInteger -- Time elapsed: 0.667 s <<< FAILURE!
java.lang.AssertionError
        at com.cedarsoftware.io.AtomicIntegerTest.testAssignAtomicInteger(AtomicIntegerTest.java:60)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)

[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   AtomicIntegerTest.testAssignAtomicInteger:60
[INFO]
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO]
```

</details>

To reproduce, run this at the root directory:

```
mvn -pl . \
    edu.illinois:nondex-maven-plugin:2.1.7:nondex \
    -Dtest=com.cedarsoftware.io.AtomicIntegerTest#testAssignAtomicInteger -DnondexRuns=10
```
(Note: The failing test might not be seen if every test happens to have the JSON string in the correct order. Try running it several times or increase the the number of runs with `-DnondexRuns=` to reproduce the issue.)

To fix this, we could convert the JSON string to a JSON element using JsonParser, so that the order doesn't matter and we are only testing the content of the JSON to see if it matches the expected output.