### PR TITLE
Fix test that fails unexpectedly in testEnumWithPrivateMembersAsField_withPrivatesOn()

### DIFF
--- a/src/test/java/com/cedarsoftware/io/EnumTests.java
+++ b/src/test/java/com/cedarsoftware/io/EnumTests.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static com.cedarsoftware.util.CollectionUtilities.listOf;
 import static org.assertj.core.api.Assertions.assertThat;
+import com.google.gson.JsonParser;
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -169,7 +170,7 @@ class EnumTests {
         String json = TestUtil.toJson(x, options);
 
         String expected = loadJson("default-enum-standalone-with-privates.json");
-        assertThat(json).isEqualToIgnoringWhitespace(expected);
+        assertThat(JsonParser.parseString(json)).isEqualTo(JsonParser.parseString(expected));
     }
 
     @Test


### PR DESCRIPTION
This PR addresses a flaky test in the `testEnumWithPrivateMembersAsField_withPrivatesOn()` method. The test fails sporadically on [line 172](https://github.com/jdereg/json-io/blob/47fe31aa3996fff6963fcf7ce65dcf2eb46dbb09/src/test/java/com/cedarsoftware/io/EnumTests.java#L172) when comparing JSON output due to differences in formatting, such as key order, which are not fully handled by the current isEqualToIgnoringWhitespace() comparison method. 

To Reproduce the error using NonDex, run the following command in the json-io directory:

`mvn -pl . edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.cedarsoftware.io.EnumTests#testEnumWithPrivateMembersAsField_withPrivatesOn`

Note: You may need to run this line multiple times to trigger the failure, as it is non-deterministic.

<details>
<summary>This is an error that occurred under one of the NonDex runs (click to expand): </summary>

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.cedarsoftware.io.EnumTests
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.729 s <<< FAILURE! -- in com.cedarsoftware.io.EnumTests
[ERROR] com.cedarsoftware.io.EnumTests.testEnumWithPrivateMembersAsField_withPrivatesOn -- Time elapsed: 0.530 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 

Expecting actual:
  "{"@type":"com.cedarsoftware.io.EnumTests$TestEnum4","foo":"bar","age":21,"name":"B"}"
to be equal to:
  "{
  "@type": "com.cedarsoftware.io.EnumTests$TestEnum4",
  "age": 21,
  "foo": "bar",
  "name": "B"
}"
when ignoring whitespace differences
	at com.cedarsoftware.io.EnumTests.testEnumWithPrivateMembersAsField_withPrivatesOn(EnumTests.java:172)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   EnumTests.testEnumWithPrivateMembersAsField_withPrivatesOn:172 
Expecting actual:
  "{"@type":"com.cedarsoftware.io.EnumTests$TestEnum4","foo":"bar","age":21,"name":"B"}"
to be equal to:
  "{
  "@type": "com.cedarsoftware.io.EnumTests$TestEnum4",
  "age": 21,
  "foo": "bar",
  "name": "B"
}"
when ignoring whitespace differences
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
INFO: Surefire failed when running tests for hXx7D6G0xdp5Ae5YHDlPVXUfFtPUNXDs3zHUZiCevbE=
```
</details>

To fix this, the test has been updated to compare parsed JSON objects using JsonParser.parseString(), which ensures a structural comparison that ignores formatting differences like key order, rather than relying solely on isEqualToIgnoringWhitespace(). This change makes the test more robust and reliable across multiple runs.