### PR TITLE
fix: resolved nondeterministic failure in MapsTest

### DIFF
--- a/src/test/java/com/cedarsoftware/io/MapsTest.java
+++ b/src/test/java/com/cedarsoftware/io/MapsTest.java
@@ -927,15 +927,15 @@ class MapsTest
     {
         private void init()
         {
-            _strings_a = new HashMap<>();
-            _strings_b = new HashMap<>();
+            _strings_a = new LinkedHashMap<>();
+            _strings_b = new LinkedHashMap<>();
             _strings_c = null;
             _testobjs_a = new TreeMap<>();
-            _map_col = new HashMap<>();
+            _map_col = new LinkedHashMap<>();
             _map_col_2 = new TreeMap<>();
-            _map_col_3 = new HashMap<>();
-            _map_obj = new HashMap<>();
-            _map_con = new ConcurrentHashMap<>();
+            _map_col_3 = new LinkedHashMap<>();
+            _map_obj = new LinkedHashMap<>();
+            _map_con = Collections.synchronizedMap(new LinkedHashMap<>());
 
             _strings_a.put("woods", "tiger");
             _strings_a.put("mickleson", "phil");


### PR DESCRIPTION
This PR addresses a flaky test in test `testMap()` of [MapsTest.java](https://github.com/jdereg/json-io/blob/master/src/test/java/com/cedarsoftware/io/MapsTest.java).

## Description
The nondeterministic behavior in the `testMap()` method of MapsTest.java occurs because the `toJson()` function serializes map objects using the [writeMapToEnd](https://github.com/jdereg/json-io/blob/master/src/main/java/com/cedarsoftware/io/JsonWriter.java) method, which iterates over the `HashMap` keys and values separately. However, the iteration order of a `HashMap` is not guaranteed, and may cause the test to fail when deserializing back to a map object and comparing element orders.

## Steps to reproduce
I used [Nondex](https://github.com/TestingResearchIllinois/NonDex) to introduce randomness by running `mvn -pl . edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.cedarsoftware.io.MapsTest#testMap`.

## Expected Behaviour
This test should pass consistently, regardless of the order of fields in HashMaps. Specifically, in `_map_obj`, key `null` should be mapped to `null`, and `99` should be mapped to `0.123`.

## Actual Behaviour
The test occasionally fails, raise an exception with error message:

> [ERROR] Failures: 
[ERROR]   MapsTest.testMap:128->assertMap:453 expected: <null> but was: <0.123>

The error message indicates that key `null` was accidentally mapped to value `0.123`.

## Proposed Solution
To ensure consistent ordering of keys and values in the map serialization process, I replaced `HashMap` with `LinkedHashMap` in the class `ManyMaps` being tested, where iteration order is preserved during both serialization and deserialization.

I’m open to further discussion or modifications if needed to improve the solution or address any concerns. Thank you!