### PR TITLE
Test Fix: Resolve unintended test failures caused by non-deterministic ordering of delta objects.

### DIFF
--- a/src/test/java/com/cedarsoftware/io/TestGraphComparatorList.java
+++ b/src/test/java/com/cedarsoftware/io/TestGraphComparatorList.java
@@ -670,23 +670,26 @@ public class TestGraphComparatorList
 
         List<Delta> deltas = compare(persons[0], persons[1], getIdFetcher());
         assertTrue(deltas.size() == 3);
-        Delta delta = deltas.get(0);
-        assertTrue(LIST_SET_ELEMENT == delta.getCmd());
-        assertTrue("pets".equals(delta.getFieldName()));
-        assertTrue(0 == (Integer) delta.getOptionalKey());
-        assertTrue(persons[1].pets.get(0).equals(delta.getTargetValue()));
-        assertTrue((Long) delta.getId() == id);
 
-        delta = deltas.get(1);
+        deltas.sort(Comparator.comparing(Delta::getCmd).thenComparing(Delta::getFieldName));
+
+        Delta delta = deltas.get(0);
         assertTrue(OBJECT_ASSIGN_FIELD == delta.getCmd());
         assertTrue("favoritePet".equals(delta.getFieldName()));
         assertTrue(null == delta.getOptionalKey());
         assertTrue(persons[1].pets.get(0).equals(delta.getTargetValue()));
         assertTrue((Long) delta.getId() == id);
 
-        delta = deltas.get(2);
+        delta = deltas.get(1);
         assertTrue(OBJECT_ORPHAN == delta.getCmd());
         assertTrue(edId == (Long) delta.getId());
+
+        delta = deltas.get(2);
+        assertTrue(LIST_SET_ELEMENT == delta.getCmd());
+        assertTrue("pets".equals(delta.getFieldName()));
+        assertTrue(0 == (Integer) delta.getOptionalKey());
+        assertTrue(persons[1].pets.get(0).equals(delta.getTargetValue()));
+        assertTrue((Long) delta.getId() == id);
 
         applyDelta(persons[0], deltas, getIdFetcher(), getJavaDeltaProcessor());
         assertTrue(DeepEquals.deepEquals(persons[0], persons[1]));


### PR DESCRIPTION
Due to the non-deterministic behavior of [compare()](https://github.com/jdereg/json-io/blob/01f83bad2555d158506c36d7f5e24897d0154f05/src/test/java/com/cedarsoftware/io/TestGraphComparatorList.java#L671), the order of Delta objects in the list can vary. This may lead to an AssertionError when comparing a delta object with its expected value.

The example below shows a failure under NonDex on [line 674](https://github.com/jdereg/json-io/blob/01f83bad2555d158506c36d7f5e24897d0154f05/src/test/java/com/cedarsoftware/io/TestGraphComparatorList.java#L674), where we printed the list of Delta objects.

<details>

<summary>Click on to see more details on the error message when running each test</summary>

```
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.cedarsoftware.io.TestGraphComparatorList
java-util using server id=81 for last two digits of generated unique IDs. Set using new SecureRandom()
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.cedarsoftware.util.ReflectionUtils (file:/home/jakew4/.m2/repository/com/cedarsoftware/java-util/2.18.0/java-util-2.18.0.jar) to field java.lang.String.hash
WARNING: Please consider reporting this to the maintainers of com.cedarsoftware.util.ReflectionUtils
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Delta 0: Cmd=OBJECT_ASSIGN_FIELD, FieldName=favoritePet
Delta 1: Cmd=LIST_SET_ELEMENT, FieldName=pets
Delta 2: Cmd=OBJECT_ORPHAN, FieldName=null
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.391 s <<< FAILURE! - in com.cedarsoftware.io.TestGraphComparatorList
[ERROR] com.cedarsoftware.io.TestGraphComparatorList.testNewArrayElement  Time elapsed: 0.363 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at org.junit.jupiter.api.AssertTrue.failNotTrue(AssertTrue.java:63)
        at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:36)
        at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:31)
        at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:179)
        at com.cedarsoftware.io.TestGraphComparatorList.testNewArrayElement(TestGraphComparatorList.java:683)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestGraphComparatorList.testNewArrayElement:683 expected: <true> but was: <false>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO]

--------------------------------------------------------------------------------------------------------------------------------------------

[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.cedarsoftware.io.TestGraphComparatorList
java-util using server id=77 for last two digits of generated unique IDs. Set using new SecureRandom()
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.cedarsoftware.util.ReflectionUtils (file:/home/jakew4/.m2/repository/com/cedarsoftware/java-util/2.18.0/java-util-2.18.0.jar) to field java.lang.String.hash
WARNING: Please consider reporting this to the maintainers of com.cedarsoftware.util.ReflectionUtils
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Delta 0: Cmd=LIST_SET_ELEMENT, FieldName=pets
Delta 1: Cmd=OBJECT_ASSIGN_FIELD, FieldName=favoritePet
Delta 2: Cmd=OBJECT_ORPHAN, FieldName=null
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.359 s - in com.cedarsoftware.io.TestGraphComparatorList
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
```

</details>
As shown here, the order of the Delta objects in the list is non-deterministic.

To reproduce each, run these at the root directory:

```
mvn  edu.illinois:nondex-maven-plugin:2.1.7:nondex     -Dtest=com.cedarsoftware.io.TestGraphComparatorList#testNewArrayElement -DnondexRuns=10
```
(Note: The failing test might not be seen if every test happens to have the Delta objects in the expected order. Try running it several times or increase the the number of runs with -DnondexRuns= to reproduce the issue.)


The log output can be found here for your reference:
[Uploading mvn-nondex-testNewArrayElement-1730802207.log…]()


**To resolve this**, we can first sort the Delta Objects by both Command and Field Name before comparing them with the expected values. After sorting, we can then reorder the sequence of testing for each object.

After applying the fix, the test should now pass with NonDex as expected:

```
[INFO] *********
[INFO] All tests pass without NonDex shuffling
[INFO] ####################
[INFO] Across all seeds:
[INFO] Test results can be found at: 
[INFO] file:///home/jakew4/json-io/.nondex/BaH4TEjf+v2WQmT7GAKNbNydKfNrSmYv4cpvV5m6s=/test_results.html
[INFO] [NonDex] The id of this run is: BaH4TEjf+v2WQmT7GAKNbNydKfNrSmYv4cpvV5m6s=
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  21.923 s
[INFO] Finished at: 2024-11-05T05:00:33-06:00
[INFO] ------------------------------------------------------------------------
```

Please let me know if this approach works for you. If not, I'm happy to discuss alternatives and am willing to spend more time to address the test in the way you'd prefer. Thank you!