### PR TITLE
fix: EnumSet support

### DIFF
--- a/src/main/java/com/cedarsoftware/io/factory/EnumSetFactory.java
+++ b/src/main/java/com/cedarsoftware/io/factory/EnumSetFactory.java
@@ -45,6 +45,9 @@ public class EnumSetFactory implements JsonReader.ClassFactory {
                     // Since we cannot determine the enum class from the string, throw an exception
                     throw new JsonIoException("Unable to determine enum class from items in EnumSet");
                 }
+            } else {
+                // in case of field is serialized without values, but it's mentioned as java.util.RegularEnumSet
+                return null;
             }
         }
 

--- a/src/test/java/com/cedarsoftware/io/EnumSetContainerTest.java
+++ b/src/test/java/com/cedarsoftware/io/EnumSetContainerTest.java
@@ -102,6 +102,28 @@ class EnumSetContainerTest {
     }
 
     @Test
+    void testEnumSet_asClassFieldEmptyLegacyWritten() {
+        String json = "{" +
+                "  \"@type\" : \"com.cedarsoftware.io.EnumSetContainerTest$EnumSetContainer\"," +
+                "  \"set1\" : {" +
+                "    \"@type\": \"java.util.RegularEnumSet\"" +
+                "  }," +
+                "  \"set2\" : {" +
+                "    \"@type\": \"java.util.RegularEnumSet\"" +
+                "  }," +
+                "  \"nullSet\" : {" +
+                "    \"@type\": \"java.util.RegularEnumSet\"" +
+                "  }\n" +
+                "}";
+
+        EnumSetContainer target = TestUtil.toObjects(json, null);
+
+        assertThat(target.set1).isNull();
+        assertThat(target.set2).isNull();
+        assertThat(target.nullSet).isNull();
+    }
+
+    @Test
     void testEnumSet_inNestedCollections() {
         // Map<String, List<EnumSet<TestEnum>>>
         Map<String, List<EnumSet<TestEnum>>> source = new LinkedHashMap<>();


### PR DESCRIPTION
* legacy written enumset without values and without type

Note: I found the file that was serialized in 2017 that's why I suppose that a legacy json-io serializer was able to write such JSON