### PR TITLE
Defer class resolution in parser

### DIFF
--- a/src/main/java/com/cedarsoftware/io/JsonParser.java
+++ b/src/main/java/com/cedarsoftware/io/JsonParser.java
@@ -343,8 +343,8 @@ class JsonParser {
             // Process key-value pairing.
             switch (field) {
                 case TYPE:
-                    Class<?> type = loadType(value);
-                    jObj.setType(type);
+                    String typeName = loadType(value);
+                    jObj.setTypeName(typeName);
                     break;
 
                 case ENUM:  // Legacy support (@enum was used to indicate EnumSet in prior versions)
@@ -854,8 +854,12 @@ class JsonParser {
         if (!(value instanceof String)) {
             error("Expected a String for " + ENUM + ", instead got: " + value);
         }
-        Class<?> enumClass = stringToClass((String) value);
-        jObj.setType(enumClass);
+        String enumClassName = (String) value;
+        String substitute = readOptions.getTypeNameAlias(enumClassName);
+        if (substitute != null) {
+            enumClassName = substitute;
+        }
+        jObj.setTypeName(enumClassName);
 
         // Only set empty items if no items were specified in JSON
         if (jObj.getItems() == null) {
@@ -868,7 +872,7 @@ class JsonParser {
      *
      * @param value Object should be a String, if not an exception is thrown.  It is the value associated to the @type field.
      */
-    private Class<?> loadType(Object value) {
+    private String loadType(Object value) {
         if (!(value instanceof String)) {
             error("Expected a String for " + TYPE + ", instead got: " + value);
         }
@@ -878,8 +882,8 @@ class JsonParser {
             javaType = substitute;
         }
 
-        // Resolve class during parsing
-        return stringToClass(javaType);
+        // Defer class resolution
+        return javaType;
     }
 
     /**

--- a/src/main/java/com/cedarsoftware/io/JsonValue.java
+++ b/src/main/java/com/cedarsoftware/io/JsonValue.java
@@ -47,6 +47,8 @@ public abstract class JsonValue {
     protected Long refId = null;
     protected int line;
     protected int col;
+    // Hold the raw @type/@enum string when the class cannot be resolved during parsing
+    String typeName = null;
 
     // Cache for storing whether a Type is fully resolved.
     private static final Map<Type, Boolean> typeResolvedCache = new ConcurrentHashMap<>();
@@ -140,7 +142,15 @@ public abstract class JsonValue {
         if (type != null) {
             return TypeUtilities.getRawClass(type).getName();
         }
-        return null;
+        return typeName;
+    }
+
+    public String getTypeName() {
+        return typeName;
+    }
+
+    public void setTypeName(String typeName) {
+        this.typeName = typeName;
     }
 
     public long getId() {
@@ -162,6 +172,7 @@ public abstract class JsonValue {
     void clear() {
         id = -1;
         type = null;
+        typeName = null;
         refId = null;
     }
 

--- a/src/main/java/com/cedarsoftware/io/MapResolver.java
+++ b/src/main/java/com/cedarsoftware/io/MapResolver.java
@@ -203,6 +203,7 @@ public class MapResolver extends Resolver {
 
                 if (refId == null) {
                     // Convert JsonObject to its destination type if possible
+                    resolvePendingType(jsonObject);
                     Class<?> type = jsonObject.getRawType();
                     if (type != null && converter.isConversionSupportedFor(Map.class, type)) {
                         Object converted = converter.convert(jsonObject, type);
@@ -213,6 +214,7 @@ public class MapResolver extends Resolver {
                     }
                 } else {    // Connect reference
                     JsonObject refObject = refTracker.getOrThrow(refId);
+                    resolvePendingType(refObject);
                     Class<?> type = refObject.getRawType();
 
                     if (type != null && converter.isConversionSupportedFor(Map.class, type)) {
@@ -281,6 +283,7 @@ public class MapResolver extends Resolver {
                     } else {
                         jObj.setType(Object.class);
                         createInstance(jObj);
+                        resolvePendingType(jObj);
                         boolean isNonRefClass = getReadOptions().isNonReferenceableClass(jObj.getRawType());
                         if (!isNonRefClass) {
                             traverseSpecificType(jObj);

--- a/src/main/java/com/cedarsoftware/io/ObjectResolver.java
+++ b/src/main/java/com/cedarsoftware/io/ObjectResolver.java
@@ -134,6 +134,7 @@ public class ObjectResolver extends Resolver
             }
 
             final JsonObject jObj = (JsonObject) rhs;
+            resolvePendingType(jObj);
             Type explicitType = jObj.getType();
             if (explicitType != null && !TypeUtilities.hasUnresolvedType(explicitType)) {
                 // If the field has an explicit type, use it.

--- a/src/test/java/com/cedarsoftware/io/JsonParserTypeStringTest.java
+++ b/src/test/java/com/cedarsoftware/io/JsonParserTypeStringTest.java
@@ -1,0 +1,27 @@
+package com.cedarsoftware.io;
+
+import java.io.StringReader;
+
+import com.cedarsoftware.io.JsonReader.DefaultReferenceTracker;
+import com.cedarsoftware.util.FastReader;
+import com.cedarsoftware.util.convert.Converter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Test that JsonParser keeps @type values as Strings during parsing. */
+public class JsonParserTypeStringTest {
+    @Test
+    public void testParserKeepsTypeName() throws Exception {
+        String json = "{\"@type\":\"some.missing.Type\",\"value\":1}";
+        ReadOptions options = new ReadOptionsBuilder().returnAsJsonObjects().failOnUnknownType(false).build();
+        Converter converter = new Converter(options.getConverterOptions());
+        MapResolver resolver = new MapResolver(options, new DefaultReferenceTracker(), converter);
+        JsonParser parser = new JsonParser(new FastReader(new StringReader(json)), resolver);
+        Object obj = parser.readValue(Object.class);
+        assertTrue(obj instanceof JsonObject);
+        JsonObject jObj = (JsonObject) obj;
+        assertNull(jObj.getType());
+        assertEquals("some.missing.Type", jObj.getRawTypeName());
+    }
+}


### PR DESCRIPTION
## Summary
- add `typeName` to `JsonValue` for unresolved type strings
- modify `JsonParser` to store type names instead of loading classes
- resolve type names later in `Resolver`
- update MapResolver/ObjectResolver to handle pending types
- add unit test verifying parser keeps type names

## Testing
- `mvn -q test` *(fails: `mvn` not found)*