### PR TITLE
Fix record test for JDK8

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 #### 4.55.0 (unreleased) Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.2` to `3.3.3.`
 * Fixed deserialization of Java records
+* Tests now create record classes via reflection for JDK 8 compatibility
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/RecordDeserializationTest.java
+++ b/src/test/java/com/cedarsoftware/io/RecordDeserializationTest.java
@@ -1,34 +1,83 @@
 package com.cedarsoftware.io;
 
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RecordDeserializationTest {
-    public static class TestPojo {
-        public int number;
-        public String string;
-        public RecordPojo subPojo;
-
-        public TestPojo(int number, String string, RecordPojo subPojo) {
-            this.number = number;
-            this.string = string;
-            this.subPojo = subPojo;
+    private static boolean recordsSupported() {
+        try {
+            Class.forName("java.lang.Record");
+            return true;
+        } catch (Exception ignore) {
+            return false;
         }
     }
 
-    public static record RecordPojo(String subString, int iSubNumber) {}
-
     @Test
-    public void testRecordRoundTrip() {
-        TestPojo testPojo = new TestPojo(3, "myString", new RecordPojo("subString", 42));
-        String json = JsonIo.toJson(testPojo, null);
-        TestPojo clone = JsonIo.toJava(json, null).asClass(TestPojo.class);
+    public void testRecordRoundTrip() throws Exception {
+        Assumptions.assumeTrue(recordsSupported(), "Records not supported");
 
-        assertEquals(3, clone.number);
-        assertEquals("myString", clone.string);
-        assertEquals("subString", clone.subPojo.subString());
-        assertEquals(42, clone.subPojo.iSubNumber());
+        Path dir = Files.createTempDirectory("recordTest");
+        Path recordFile = dir.resolve("RecordPojo.java");
+        Files.write(recordFile,
+                ("public record RecordPojo(String subString, int iSubNumber) {}" + System.lineSeparator())
+                        .getBytes(StandardCharsets.UTF_8));
+        Path testFile = dir.resolve("TestPojo.java");
+        Files.write(testFile,
+                ("public class TestPojo {" +
+                        "  public int number;" +
+                        "  public String string;" +
+                        "  public RecordPojo subPojo;" +
+                        "  public TestPojo(int number, String string, RecordPojo subPojo) {" +
+                        "    this.number = number;" +
+                        "    this.string = string;" +
+                        "    this.subPojo = subPojo;" +
+                        "  }" +
+                        "}" + System.lineSeparator()).getBytes(StandardCharsets.UTF_8));
+
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        int result = compiler.run(null, null, null,
+                recordFile.toString(), testFile.toString(), "-d", dir.toString());
+        if (result != 0) {
+            throw new IllegalStateException("Compilation failed");
+        }
+
+        URLClassLoader loader = URLClassLoader.newInstance(new URL[]{dir.toUri().toURL()});
+        Class<?> recordClass = Class.forName("RecordPojo", true, loader);
+        Class<?> testClass = Class.forName("TestPojo", true, loader);
+
+        Constructor<?> recordCtor = recordClass.getDeclaredConstructor(String.class, int.class);
+        Object record = recordCtor.newInstance("subString", 42);
+        Constructor<?> testCtor = testClass.getDeclaredConstructor(int.class, String.class, recordClass);
+        Object testPojo = testCtor.newInstance(3, "myString", record);
+
+        String json = JsonIo.toJson(testPojo, null);
+        Object clone = JsonIo.toJava(json, null).asClass(testClass);
+
+        Field numberField = testClass.getField("number");
+        Field stringField = testClass.getField("string");
+        Field subPojoField = testClass.getField("subPojo");
+
+        assertEquals(3, numberField.getInt(clone));
+        assertEquals("myString", stringField.get(clone));
+        Object cloneSub = subPojoField.get(clone);
+        Method subString = recordClass.getMethod("subString");
+        Method iSubNumber = recordClass.getMethod("iSubNumber");
+        assertEquals("subString", subString.invoke(cloneSub));
+        assertEquals(42, iSubNumber.invoke(cloneSub));
     }
 }
 


### PR DESCRIPTION
## Summary
- handle record tests with reflection to support JDK8
- note new test approach in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685256fe4204832a81b493170f734db3