### PR TITLE
Add raw type string tracking

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * Tests now create record classes via reflection for JDK 8 compatibility
 * SealableNavigableMap now wraps returned entries to enforce immutability
 * Documentation expanded for CompactMap usage and builder() caveats
+* JsonObject exposes `getTypeString()` with the raw `@type` value
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/main/java/com/cedarsoftware/io/JsonObject.java
+++ b/src/main/java/com/cedarsoftware/io/JsonObject.java
@@ -42,9 +42,10 @@ public class JsonObject extends JsonValue implements Map<Object, Object> {
     // Explicit fields for meta data
     private Object[] items;
     private Object[] keys;
+    private String typeString;
 
     public String toString() {
-        String jType = type == null ? "not set" : type.getTypeName();
+        String jType = typeString != null ? typeString : (type == null ? "not set" : type.getTypeName());
         String targetInfo = target == null ? "null" : jType;
         return "JsonObject(id:" + id + ", type:" + jType + ", target:" + targetInfo + ", line:" + line + ", col:" + col + ", size:" + size() + ")";
     }
@@ -111,6 +112,19 @@ public class JsonObject extends JsonValue implements Map<Object, Object> {
         }
         this.keys = keys;
         hash = null;
+    }
+
+    /**
+     * Return the raw value provided for the {@code @type} field, if any.
+     *
+     * @return String containing the raw type name or {@code null} if none was provided
+     */
+    public String getTypeString() {
+        return typeString;
+    }
+
+    void setTypeString(String typeString) {
+        this.typeString = typeString;
     }
 
     public int size() {

--- a/src/main/java/com/cedarsoftware/io/JsonParser.java
+++ b/src/main/java/com/cedarsoftware/io/JsonParser.java
@@ -344,6 +344,7 @@ class JsonParser {
             switch (field) {
                 case TYPE:
                     Class<?> type = loadType(value);
+                    jObj.setTypeString((String) value);
                     jObj.setType(type);
                     break;
 
@@ -855,6 +856,7 @@ class JsonParser {
             error("Expected a String for " + ENUM + ", instead got: " + value);
         }
         Class<?> enumClass = stringToClass((String) value);
+        jObj.setTypeString((String) value);
         jObj.setType(enumClass);
 
         // Only set empty items if no items were specified in JSON

--- a/user-guide.md
+++ b/user-guide.md
@@ -85,6 +85,9 @@ jsonMap.put("name", "John Doe");
 String updatedJson = JsonIo.toJson(jsonMap, writeOptions);
 ```
 
+Each `JsonObject` retains the raw `@type` value from the input JSON. Call
+`getTypeString()` to retrieve this value without triggering type resolution.
+
 ### Generic Type Support
 For working with generic types like `List<Employee>` or complex nested generics, use the `TypeHolder` class to preserve full generic type information:
 


### PR DESCRIPTION
## Summary
- extend JsonObject with `typeString`
- store the raw `@type` text during parsing
- expose `getTypeString()` for access to the stored value
- document new API

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68532b7abe40832aa2191bbcaea6c32f