### PR TITLE
Fix alias handling for lazy type resolution

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Documentation expanded for CompactMap usage and builder() caveats
 * JsonObject exposes `getTypeString()` with the raw `@type` value
 * Parser defers class loading for `@type` and `@enum` fields
+* Deferred resolution now respects type aliases when loading classes
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/main/java/com/cedarsoftware/io/JsonParser.java
+++ b/src/main/java/com/cedarsoftware/io/JsonParser.java
@@ -916,7 +916,8 @@ class JsonParser {
     }
 
     private Class<?> stringToClass(String className) {
-        Class<?> clazz = ClassUtilities.forName(className, readOptions.getClassLoader());
+        String resolvedName = readOptions.getTypeNameAlias(className);
+        Class<?> clazz = ClassUtilities.forName(resolvedName, readOptions.getClassLoader());
         if (clazz == null) {
             if (readOptions.isFailOnUnknownType()) {
                 error("Unknown type (class) '" + className + "' not defined.");

--- a/src/main/java/com/cedarsoftware/io/JsonReader.java
+++ b/src/main/java/com/cedarsoftware/io/JsonReader.java
@@ -785,7 +785,8 @@ public class JsonReader implements Closeable
     }
 
     private Class<?> stringToClass(String className) {
-        Class<?> clazz = ClassUtilities.forName(className, readOptions.getClassLoader());
+        String resolvedName = readOptions.getTypeNameAlias(className);
+        Class<?> clazz = ClassUtilities.forName(resolvedName, readOptions.getClassLoader());
         if (clazz == null) {
             if (readOptions.isFailOnUnknownType()) {
                 throw new JsonIoException("Unknown type (class) '" + className + "' not defined.");

--- a/src/main/java/com/cedarsoftware/io/Resolver.java
+++ b/src/main/java/com/cedarsoftware/io/Resolver.java
@@ -541,7 +541,8 @@ public abstract class Resolver {
     }
 
     private Class<?> stringToClass(String className) {
-        Class<?> clazz = ClassUtilities.forName(className, readOptions.getClassLoader());
+        String resolvedName = readOptions.getTypeNameAlias(className);
+        Class<?> clazz = ClassUtilities.forName(resolvedName, readOptions.getClassLoader());
         if (clazz == null) {
             if (readOptions.isFailOnUnknownType()) {
                 throw new JsonIoException("Unknown type (class) '" + className + "' not defined.");


### PR DESCRIPTION
## Summary
- ensure `JsonParser`, `JsonReader`, and `Resolver` translate type aliases when converting strings to classes
- note alias fix in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685335996da0832a888980f47bf67b50