### PR TITLE
Revert lazy type resolution

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,8 +6,6 @@
 * SealableNavigableMap now wraps returned entries to enforce immutability
 * Documentation expanded for CompactMap usage and builder() caveats
 * JsonObject exposes `getTypeString()` with the raw `@type` value
-* Parser defers class loading for `@type` and `@enum` fields
-* Deferred resolution now respects type aliases when loading classes
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/main/java/com/cedarsoftware/io/JsonParser.java
+++ b/src/main/java/com/cedarsoftware/io/JsonParser.java
@@ -343,10 +343,9 @@ class JsonParser {
             // Process key-value pairing.
             switch (field) {
                 case TYPE:
-                    if (!(value instanceof String)) {
-                        error("Expected a String for " + TYPE + ", instead got: " + value);
-                    }
+                    Class<?> type = loadType(value);
                     jObj.setTypeString((String) value);
+                    jObj.setType(type);
                     break;
 
                 case ENUM:  // Legacy support (@enum was used to indicate EnumSet in prior versions)
@@ -856,7 +855,9 @@ class JsonParser {
         if (!(value instanceof String)) {
             error("Expected a String for " + ENUM + ", instead got: " + value);
         }
+        Class<?> enumClass = stringToClass((String) value);
         jObj.setTypeString((String) value);
+        jObj.setType(enumClass);
 
         // Only set empty items if no items were specified in JSON
         if (jObj.getItems() == null) {

--- a/src/main/java/com/cedarsoftware/io/JsonReader.java
+++ b/src/main/java/com/cedarsoftware/io/JsonReader.java
@@ -690,13 +690,7 @@ public class JsonReader implements Closeable
         try {
             // Determine the root type if not explicitly provided
             if (rootType == null) {
-                if (rootObj.getType() != null) {
-                    rootType = rootObj.getType();
-                } else if (rootObj.getTypeString() != null) {
-                    rootType = stringToClass(rootObj.getTypeString());
-                } else {
-                    rootType = Object.class;
-                }
+                rootType = rootObj.getType() == null ? Object.class : rootObj.getType();
             }
 
             // Delegate the conversion to the resolver using the converter
@@ -782,21 +776,6 @@ public class JsonReader implements Closeable
             return msg + "\nLast read: " + input.getLastSnippet() + "\nline: " + input.getLine() + ", col: " + input.getCol();
         }
         return msg;
-    }
-
-    private Class<?> stringToClass(String className) {
-        String resolvedName = readOptions.getTypeNameAlias(className);
-        Class<?> clazz = ClassUtilities.forName(resolvedName, readOptions.getClassLoader());
-        if (clazz == null) {
-            if (readOptions.isFailOnUnknownType()) {
-                throw new JsonIoException("Unknown type (class) '" + className + "' not defined.");
-            }
-            clazz = readOptions.getUnknownTypeClass();
-            if (clazz == null) {
-                clazz = LinkedHashMap.class;
-            }
-        }
-        return clazz;
     }
 
     /**

--- a/src/main/java/com/cedarsoftware/io/Resolver.java
+++ b/src/main/java/com/cedarsoftware/io/Resolver.java
@@ -212,14 +212,7 @@ public abstract class Resolver {
             return (T) rootObj.getTarget();
         } else {
             if (rootObj.getType() == null) {
-                if (rootType != null) {
-                    rootObj.setType(rootType);
-                } else if (rootObj.getTypeString() != null) {
-                    Class<?> clazz = stringToClass(rootObj.getTypeString());
-                    rootObj.setType(clazz);
-                } else {
-                    rootObj.setType(rootType);
-                }
+                rootObj.setType(rootType);
             }
             Object instance = (rootObj.getTarget() == null ? createInstance(rootObj) : rootObj.getTarget());
             if (rootObj.isFinished) {
@@ -540,20 +533,6 @@ public abstract class Resolver {
         return null;
     }
 
-    private Class<?> stringToClass(String className) {
-        String resolvedName = readOptions.getTypeNameAlias(className);
-        Class<?> clazz = ClassUtilities.forName(resolvedName, readOptions.getClassLoader());
-        if (clazz == null) {
-            if (readOptions.isFailOnUnknownType()) {
-                throw new JsonIoException("Unknown type (class) '" + className + "' not defined.");
-            }
-            clazz = readOptions.getUnknownTypeClass();
-            if (clazz == null) {
-                clazz = LinkedHashMap.class;
-            }
-        }
-        return clazz;
-    }
 
     // Determine the factory type, considering enums and collections
     private Class<?> determineFactoryType(JsonObject jsonObj, Class<?> targetType) {


### PR DESCRIPTION
## Summary
- revert lazy class resolution changes
- restore original `loadEnum` and `loadType` behavior
- cleanup changelog entry

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685339602830832a94490f88fa91a70e