### PR TITLE
Fix Maven plugin warnings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 * SealableNavigableMap now wraps returned entries to enforce immutability
 * Documentation expanded for CompactMap usage and builder() caveats
 * JsonObject exposes `getTypeString()` with the raw `@type` value
+* Pinned core Maven plugin versions to prevent Maven 4 warnings
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,11 @@
         <version.maven-bundle-plugin>6.0.0</version.maven-bundle-plugin>
         <version.moditect-maven-plugin>1.2.2.Final</version.moditect-maven-plugin>
 
+        <!-- Core plugins explicitly pinned to avoid Maven 4 warnings -->
+        <version.maven-resources-plugin>3.3.1</version.maven-resources-plugin>
+        <version.maven-install-plugin>3.1.4</version.maven-install-plugin>
+        <version.maven-deploy-plugin>3.1.4</version.maven-deploy-plugin>
+
         <!-- release to Maven Central via Sonatype Nexus -->
         <version.nexus-staging-maven-plugin>1.7.0</version.nexus-staging-maven-plugin>
 
@@ -162,6 +167,25 @@
     </distributionManagement>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${version.maven-resources-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>${version.maven-install-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${version.maven-deploy-plugin}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
 
             <plugin>


### PR DESCRIPTION
## Summary
- pin resources, install and deploy plugin versions
- document plugin version pinning in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685347b7c7fc832a8702ebfae5de4895