### PR TITLE
Improve docs for unknown type parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Key Features:
 - Lightweight (`json-io.jar` is 255K, `java-util` is 456K)
 - Compatible with JDK 1.8 through JDK 24
 - Extensive configuration options via `ReadOptionsBuilder` and `WriteOptionsBuilder`
+- Optionally parse JSON with unknown class references into a Map-of-Maps representation
 - Featured on [json.org](http://json.org)
 ## Compatibility
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Documentation expanded for CompactMap usage and builder() caveats
 * JsonObject exposes `getTypeString()` with the raw `@type` value
 * Pinned core Maven plugin versions to prevent Maven 4 warnings
+* Documentation updated with guidance for parsing JSON that references unknown classes
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/main/java/com/cedarsoftware/io/JsonIo.java
+++ b/src/main/java/com/cedarsoftware/io/JsonIo.java
@@ -73,6 +73,18 @@ import com.cedarsoftware.util.convert.DefaultConverterOptions;
  *     In this case, simple Java types may be converted (or left as is for {@code Map} types),
  *     and {@code Collection} types will be converted appropriately.
  *   </li>
+ *   <li>
+ *     <b>4. Parsing JSON with unknown class references:</b>
+ *     <pre>
+ *     ReadOptions opts = new ReadOptionsBuilder()
+ *                               .returnAsJsonObjects()
+ *                               .failOnUnknownType(false)
+ *                               .build();
+ *     Map&lt;String, Object&gt; graph = JsonIo.toJava(jsonString, opts).asClass(Map.class);
+ *     </pre>
+ *     This configuration allows any JSON to be read as a graph of maps, even when
+ *     the {@code @type} values refer to classes not present on the classpath.
+ *   </li>
  * </ul>
  * <p>
  * <b>Note:</b>

--- a/user-guide-readOptions.md
+++ b/user-guide-readOptions.md
@@ -79,6 +79,16 @@ keys and values. Using maps for unknown types provides flexibility, allowing JSO
 >- [ ] Set the class to use (defaults to`LinkedHashMap.class`) when a JSON object is encountered and there is no
    corresponding Java class to instantiate to receive the values.
 
+_Example: Parse any JSON into a Map graph_
+```java
+ReadOptions opts = new ReadOptionsBuilder()
+        .returnAsJsonObjects()
+        .failOnUnknownType(false)
+        .build();
+Map<String, Object> graph = JsonIo.toJava(json, opts).asClass(Map.class);
+```
+This configuration prevents errors for unrecognized `@type` values and ensures all objects are stored as maps.
+
 ### MaxDepth - Security protection
 Set the maximum object nesting level so that no`StackOverflowExceptions`happen.  Instead, you will get a`JsonIoException`letting
 you know that the maximum object nesting level has been reached.

--- a/user-guide.md
+++ b/user-guide.md
@@ -88,6 +88,23 @@ String updatedJson = JsonIo.toJson(jsonMap, writeOptions);
 Each `JsonObject` retains the raw `@type` value from the input JSON. Call
 `getTypeString()` to retrieve this value without triggering type resolution.
 
+### Parsing JSON with Unknown Classes
+If the JSON contains class references that are not available on the classpath,
+configure the reader to skip type resolution and return a graph of `Map`
+instances. This allows arbitrary JSON to be loaded, inspected, and
+re-serialized.
+
+```java
+ReadOptions opts = new ReadOptionsBuilder()
+        .returnAsJsonObjects()
+        .failOnUnknownType(false)
+        .build();
+Map<String, Object> graph = JsonIo.toJava(json, opts).asClass(Map.class);
+```
+
+All objects will be represented as Maps (or collections) so the entire structure
+can be traversed or modified without requiring the referenced classes.
+
 ### Generic Type Support
 For working with generic types like `List<Employee>` or complex nested generics, use the `TypeHolder` class to preserve full generic type information:
 


### PR DESCRIPTION
## Summary
- document ability to parse JSON that references unknown classes
- show failOnUnknownType(false) example in ReadOptions guide
- mention map-based parsing in main user guide and JsonIo Javadoc
- note capability in README key features
- update changelog

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685355589724832a80b2b36d331ec1b1