### PR TITLE
Add Java version check for record reading

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * JsonObject exposes `getTypeString()` with the raw `@type` value
 * Pinned core Maven plugin versions to prevent Maven 4 warnings
 * Documentation updated with guidance for parsing JSON that references unknown classes
+* RecordFactory now checks the Java version before using records
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/main/java/com/cedarsoftware/io/factory/RecordFactory.java
+++ b/src/main/java/com/cedarsoftware/io/factory/RecordFactory.java
@@ -8,6 +8,7 @@ import com.cedarsoftware.io.JsonObject;
 import com.cedarsoftware.io.JsonReader;
 import com.cedarsoftware.io.Resolver;
 import com.cedarsoftware.util.ExceptionUtilities;
+import com.cedarsoftware.util.SystemUtilities;
 
 /**
  * @author John DeRegnaucourt (jdereg@gmail.com)
@@ -27,10 +28,15 @@ import com.cedarsoftware.util.ExceptionUtilities;
  *         limitations under the License.
  */
 public class RecordFactory implements JsonReader.ClassFactory {
+    private static final boolean JAVA_16_OR_ABOVE = SystemUtilities.isJavaVersionAtLeast(16, 0);
+
     public RecordFactory() {}
 
     @Override
     public Object newInstance(Class<?> c, JsonObject jsonObj, Resolver resolver) {
+        if (!JAVA_16_OR_ABOVE) {
+            throw new RuntimeException("Record de-serialization only works with java>=16.");
+        }
         try {
             ArrayList<Class<?>> lParameterTypes = new ArrayList<>(jsonObj.size());
             ArrayList<Object> lParameterValues = new ArrayList<>(jsonObj.size());
@@ -57,8 +63,6 @@ public class RecordFactory implements JsonReader.ClassFactory {
             Constructor<?> constructor = c.getDeclaredConstructor(lParameterTypes.toArray(new Class[0]));
             ExceptionUtilities.safelyIgnoreException(() -> constructor.setAccessible(true));
             return constructor.newInstance(lParameterValues.toArray(new Object[0]));
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException("Record de-serialization only works with java>=16.", e);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -68,6 +72,9 @@ public class RecordFactory implements JsonReader.ClassFactory {
     {
         public Object read(Object o, Resolver resolver)
         {
+            if (!JAVA_16_OR_ABOVE) {
+                throw new RuntimeException("Record de-serialization only works with java>=16.");
+            }
             try {
                 JsonObject jsonObj = (JsonObject) o;
 
@@ -99,8 +106,6 @@ public class RecordFactory implements JsonReader.ClassFactory {
                 Constructor<?> constructor = c.getDeclaredConstructor(lParameterTypes.toArray(new Class[0]));
                 ExceptionUtilities.safelyIgnoreException(() -> constructor.setAccessible(true));
                 return constructor.newInstance(lParameterValues.toArray(new Object[0]));
-            } catch (NoSuchMethodException e) {
-                throw new RuntimeException("Record de-serialization only works with java>=16.", e);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
## Summary
- use SystemUtilities in RecordFactory to guard record support
- note change in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68536e399680832a9145076b4f4fcff8