### PR TITLE
Add test for StackTraceElementFactory.isObjectFinal

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * JsonObject exposes `getTypeString()` with the raw `@type` value
 * Pinned core Maven plugin versions to prevent Maven 4 warnings
 * Documentation updated with guidance for parsing JSON that references unknown classes
+* Added test covering StackTraceElementFactory.isObjectFinal()
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/factory/StackTraceElementFactoryTest.java
+++ b/src/test/java/com/cedarsoftware/io/factory/StackTraceElementFactoryTest.java
@@ -3,6 +3,7 @@ package com.cedarsoftware.io.factory;
 import java.util.stream.Stream;
 
 import com.cedarsoftware.io.JsonObject;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -35,6 +36,12 @@ class StackTraceElementFactoryTest {
         //assertThat(stackTrace.getModuleName()).isEqualTo(moduleName);
         //assertThat(stackTrace.getModuleVersion()).isEqualTo(moduleVersion);
         //assertThat(stackTrace.getClassLoaderName()).isEqualTo(classLoaderName);
+    }
+
+    @Test
+    void isObjectFinal_returnTrue() {
+        StackTraceElementFactory factory = new StackTraceElementFactory();
+        assertThat(factory.isObjectFinal()).isTrue();
     }
 
     private JsonObject buildJsonObject(String classLoaderName, String moduleName, String moduleVersion, String declaringClass, String methodName, String fileName, Long lineNumber) {


### PR DESCRIPTION
## Summary
- verify `StackTraceElementFactory.isObjectFinal()` returns true
- document new test in the changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68536f1b7d2c832a969e341de2ddcb55