### PR TITLE
Add NamedMethodFilter tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * JsonObject exposes `getTypeString()` with the raw `@type` value
 * Pinned core Maven plugin versions to prevent Maven 4 warnings
 * Documentation updated with guidance for parsing JSON that references unknown classes
+* Added NamedMethodFilter tests and null-safe handling
 * RecordFactory now checks the Java version before using records
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`

--- a/src/main/java/com/cedarsoftware/io/reflect/filters/method/NamedMethodFilter.java
+++ b/src/main/java/com/cedarsoftware/io/reflect/filters/method/NamedMethodFilter.java
@@ -28,7 +28,15 @@ public class NamedMethodFilter implements MethodFilter {
         this.methodName = methodName;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Safely handles {@code null} arguments by returning {@code false}.
+     */
     public boolean filter(Class<?> clazz, String methodName) {
+        if (clazz == null || methodName == null) {
+            return false;
+        }
         return this.clazz.equals(clazz) && this.methodName.equals(methodName);
     }
 }

--- a/src/test/java/com/cedarsoftware/io/reflect/filters/NamedMethodFilterTests.java
+++ b/src/test/java/com/cedarsoftware/io/reflect/filters/NamedMethodFilterTests.java
@@ -1,0 +1,50 @@
+package com.cedarsoftware.io.reflect.filters;
+
+import java.util.List;
+
+import com.cedarsoftware.io.WriteOptions;
+import com.cedarsoftware.io.WriteOptionsBuilder;
+import com.cedarsoftware.io.reflect.Accessor;
+import com.cedarsoftware.io.reflect.filters.method.NamedMethodFilter;
+import com.cedarsoftware.io.reflect.filters.models.GetMethodTestObject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NamedMethodFilterTests {
+
+    @Test
+    void filter_returnsTrueWhenMatch() {
+        NamedMethodFilter filter = new NamedMethodFilter(GetMethodTestObject.class, "getTest5");
+        assertThat(filter.filter(GetMethodTestObject.class, "getTest5")).isTrue();
+    }
+
+    @Test
+    void filter_returnsFalseWhenClassOrMethodDiffer() {
+        NamedMethodFilter filter = new NamedMethodFilter(GetMethodTestObject.class, "getTest5");
+        assertThat(filter.filter(GetMethodTestObject.class, "getTest4")).isFalse();
+        assertThat(filter.filter(Object.class, "getTest5")).isFalse();
+    }
+
+    @Test
+    void filter_handlesNullArgumentsGracefully() {
+        NamedMethodFilter filter = new NamedMethodFilter(GetMethodTestObject.class, "getTest5");
+        assertThat(filter.filter(null, null)).isFalse();
+        assertThat(filter.filter(GetMethodTestObject.class, null)).isFalse();
+        assertThat(filter.filter(null, "getTest5")).isFalse();
+    }
+
+    @Test
+    void integration_namedMethodFilterRemovesAccessor() {
+        WriteOptions options = new WriteOptionsBuilder()
+                .addNamedMethodFilter("noGet", GetMethodTestObject.class, "getTest5")
+                .build();
+
+        List<Accessor> accessors = options.getAccessorsForClass(GetMethodTestObject.class);
+        assertThat(accessors).hasSize(5);
+        Accessor last = accessors.get(4);
+        assertThat(last.getFieldOrMethodName()).isEqualTo("test5");
+        assertThat(last.isMethod()).isFalse();
+    }
+}
+


### PR DESCRIPTION
## Summary
- handle nulls in `NamedMethodFilter`
- test `NamedMethodFilter`
- document change in `changelog.md`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68536fc80430832a86c9674dd3aabbdc