### PR TITLE
Add tests for Injector private constructors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 * RecordFactory now uses java-util `ReflectionUtils`
 * Added RecordReader test
 * Added NamedMethodFilter tests and null-safe handling
+* Added tests for Injector's private constructors
 * RecordFactory now checks the Java version before using records
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`

--- a/src/test/java/com/cedarsoftware/io/reflect/InjectorPrivateConstructorsTest.java
+++ b/src/test/java/com/cedarsoftware/io/reflect/InjectorPrivateConstructorsTest.java
@@ -1,0 +1,59 @@
+package com.cedarsoftware.io.reflect;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InjectorPrivateConstructorsTest {
+
+    static class FieldSetTarget {
+        private String value;
+    }
+
+    static class VarHandleTarget {
+        private int number;
+    }
+
+    @Test
+    void fieldSetConstructor_injectsValue() throws Exception {
+        Field field = FieldSetTarget.class.getDeclaredField("value");
+        field.setAccessible(true);
+        Constructor<Injector> ctor = Injector.class.getDeclaredConstructor(Field.class, String.class, String.class, boolean.class);
+        ctor.setAccessible(true);
+        Injector injector = ctor.newInstance(field, "value", "value", true);
+
+        FieldSetTarget target = new FieldSetTarget();
+        injector.inject(target, "bar");
+
+        assertThat(target.value).isEqualTo("bar");
+    }
+
+    @Test
+    void varHandleConstructor_injectsValue() throws Exception {
+        Field field = VarHandleTarget.class.getDeclaredField("number");
+        field.setAccessible(true);
+
+        Class<?> methodHandlesClass = Class.forName("java.lang.invoke.MethodHandles");
+        Class<?> lookupClass = Class.forName("java.lang.invoke.MethodHandles$Lookup");
+        Method lookupMethod = methodHandlesClass.getMethod("lookup");
+        Object lookup = lookupMethod.invoke(null);
+        Method privateLookupInMethod = methodHandlesClass.getMethod("privateLookupIn", Class.class, lookupClass);
+        Object privateLookup = privateLookupInMethod.invoke(null, VarHandleTarget.class, lookup);
+        Method findVarHandleMethod = lookupClass.getMethod("findVarHandle", Class.class, String.class, Class.class);
+        Object varHandle = findVarHandleMethod.invoke(privateLookup, VarHandleTarget.class, "number", int.class);
+
+        Constructor<Injector> ctor = Injector.class.getDeclaredConstructor(Field.class, Object.class, String.class, String.class);
+        ctor.setAccessible(true);
+        Injector injector = ctor.newInstance(field, varHandle, "number", "number");
+
+        VarHandleTarget target = new VarHandleTarget();
+        injector.inject(target, 42);
+
+        assertThat(target.number).isEqualTo(42);
+    }
+}


### PR DESCRIPTION
## Summary
- exercise Injector's private constructors using reflection
- document the new tests in changelog

## Testing
- `mvn -q test` *(failed: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853737398a0832aabb1adbe422e013c