### PR TITLE
Add Injector tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 * Added RecordReader test
 * Added NamedMethodFilter tests and null-safe handling
 * RecordFactory now checks the Java version before using records
+* Added Injector tests for VarHandle injection and getters
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/reflect/InjectorTests.java
+++ b/src/test/java/com/cedarsoftware/io/reflect/InjectorTests.java
@@ -1,0 +1,59 @@
+package com.cedarsoftware.io.reflect;
+
+import com.cedarsoftware.io.JsonIoException;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class InjectorTests {
+
+    private static class Sample {
+        private int value;
+    }
+
+    @Test
+    void injectWithVarHandle_setsFieldValue() throws Exception {
+        Field field = Sample.class.getDeclaredField("value");
+        Method create = Injector.class.getDeclaredMethod("createWithVarHandle", Field.class, String.class);
+        create.setAccessible(true);
+        Injector injector = (Injector) create.invoke(null, field, "num");
+        assertThat(injector).isNotNull();
+
+        Method injectMethod = Injector.class.getDeclaredMethod("injectWithVarHandle", Object.class, Object.class);
+        injectMethod.setAccessible(true);
+
+        Sample sample = new Sample();
+        injectMethod.invoke(injector, sample, 42);
+        assertThat(sample.value).isEqualTo(42);
+        assertThat(injector.getDisplayName()).isEqualTo("value");
+        assertThat(injector.getUniqueFieldName()).isEqualTo("num");
+    }
+
+    @Test
+    void injectWithVarHandle_whenVarHandleMissing_throwsException() throws Exception {
+        Field field = Sample.class.getDeclaredField("value");
+        Method create = Injector.class.getDeclaredMethod("createWithVarHandle", Field.class, String.class);
+        create.setAccessible(true);
+        Injector injector = (Injector) create.invoke(null, field, "num");
+        assertThat(injector).isNotNull();
+
+        Field vhField = Injector.class.getDeclaredField("varHandle");
+        vhField.setAccessible(true);
+        vhField.set(injector, null);
+
+        Method injectMethod = Injector.class.getDeclaredMethod("injectWithVarHandle", Object.class, Object.class);
+        injectMethod.setAccessible(true);
+
+        Sample sample = new Sample();
+        InvocationTargetException ex = assertThrows(InvocationTargetException.class, () ->
+                injectMethod.invoke(injector, sample, 1));
+        Throwable cause = ex.getCause();
+        assertThat(cause).isInstanceOf(JsonIoException.class);
+        assertThat(cause.getMessage()).contains("VarHandle not available");
+    }
+}


### PR DESCRIPTION
## Summary
- cover Injector's private VarHandle helper via reflection
- check public getter methods
- note change in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685373bff1cc832ab398eb2eecdca00f