### PR TITLE
Fix VarHandle reflection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 * Added RecordReader test
 * Added NamedMethodFilter tests and null-safe handling
 * Added tests for Injector's private constructors
+* Fixed VarHandle reflection to allow private-constructor injector
 * RecordFactory now checks the Java version before using records
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`

--- a/src/main/java/com/cedarsoftware/io/reflect/Injector.java
+++ b/src/main/java/com/cedarsoftware/io/reflect/Injector.java
@@ -61,7 +61,10 @@ public class Injector {
 
                 varHandleClass = Class.forName("java.lang.invoke.VarHandle");
                 findVarHandleMethod = lookupClass.getMethod("findVarHandle", Class.class, String.class, Class.class);
-                varHandleSetMethod = varHandleClass.getMethod("set", Object.class, Object.class);
+                // VarHandle#set is declared with a varargs parameter. Retrieve the
+                // Method instance using the actual varargs signature so reflection
+                // invocation works across JDK versions.
+                varHandleSetMethod = varHandleClass.getMethod("set", Object[].class);
             } catch (Exception e) {
                 // VarHandle reflection setup failed.
                 lookup = null;


### PR DESCRIPTION
## Summary
- ensure VarHandle#set is retrieved using the proper varargs signature
- document fix in the changelog

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6853759b105c832ab84a33050a3cf9e7