### PR TITLE
Fix varhandle injection invocation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 * RecordFactory now checks the Java version before using records
 * Added additional SealableList tests for remaining APIs
 * Added Injector tests for VarHandle injection and getters
+* Fixed VarHandle injection invocation for reflection-based Injector
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/main/java/com/cedarsoftware/io/reflect/Injector.java
+++ b/src/main/java/com/cedarsoftware/io/reflect/Injector.java
@@ -227,7 +227,7 @@ public class Injector {
         if (varHandle == null || VAR_HANDLE_SET_METHOD == null) {
             throw new JsonIoException("Unable to set field: " + getName() + " - VarHandle not available");
         }
-        VAR_HANDLE_SET_METHOD.invoke(varHandle, object, value);
+        VAR_HANDLE_SET_METHOD.invoke(varHandle, new Object[] {object, value});
     }
 
     public Class<?> getType() {


### PR DESCRIPTION
## Summary
- use an object array when invoking VarHandle#set via reflection
- document the fix in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853770f9348832ab107c78ae8487a48