### PR TITLE
Add Accessor getter tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 * RecordFactory now checks the Java version before using records
 * Added additional SealableList tests for remaining APIs
 * Added Injector tests for VarHandle injection and getters
+* Added tests for `Accessor.getMethodHandle()` and `getGenericType()`
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/reflect/AccessorTests.java
+++ b/src/test/java/com/cedarsoftware/io/reflect/AccessorTests.java
@@ -1,0 +1,37 @@
+package com.cedarsoftware.io.reflect;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import com.cedarsoftware.io.reflect.filters.models.Car;
+import com.cedarsoftware.io.reflect.filters.models.Part;
+import com.cedarsoftware.io.reflect.filters.models.GetMethodTestObject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AccessorTests {
+
+    @Test
+    void getMethodHandle_returnsHandleWhenAccessible() throws Throwable {
+        Field field = GetMethodTestObject.class.getField("test5");
+        Accessor accessor = Accessor.createFieldAccessor(field, "test5");
+        assertThat(accessor.getMethodHandle()).isNotNull();
+
+        GetMethodTestObject obj = new GetMethodTestObject();
+        Object value = accessor.getMethodHandle().invoke(obj);
+        assertThat(value).isEqualTo("foo");
+    }
+
+    @Test
+    void getGenericType_returnsParameterizedType() throws Exception {
+        Field field = Car.class.getDeclaredField("installedParts");
+        Accessor accessor = Accessor.createFieldAccessor(field, "installedParts");
+        Type type = accessor.getGenericType();
+
+        assertThat(type).isInstanceOf(ParameterizedType.class);
+        ParameterizedType pType = (ParameterizedType) type;
+        assertThat(pType.getActualTypeArguments()[0]).isEqualTo(Part.class);
+    }
+}


### PR DESCRIPTION
## Summary
- add missing JUnit tests for Accessor methods
- document test coverage improvement in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685377977034832a95479046008f6c0d