### PR TITLE
Add tests for Injector.getUniqueFieldName

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 * RecordFactory now checks the Java version before using records
 * Added additional SealableList tests for remaining APIs
 * Added Injector tests for VarHandle injection and getters
+* Added tests for Injector.getUniqueFieldName()
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/reflect/InjectorGetUniqueFieldNameTest.java
+++ b/src/test/java/com/cedarsoftware/io/reflect/InjectorGetUniqueFieldNameTest.java
@@ -1,0 +1,37 @@
+package com.cedarsoftware.io.reflect;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InjectorGetUniqueFieldNameTest {
+
+    private static class Sample {
+        private int number;
+        private int value;
+
+        void setNumber(int number) {
+            this.number = number;
+        }
+    }
+
+    @Test
+    void create_withField_preservesUniqueName() throws Exception {
+        Field field = Sample.class.getDeclaredField("value");
+        Injector injector = Injector.create(field, "val");
+
+        assertThat(injector).isNotNull();
+        assertThat(injector.getUniqueFieldName()).isEqualTo("val");
+    }
+
+    @Test
+    void create_withMethod_preservesUniqueName() throws Exception {
+        Field field = Sample.class.getDeclaredField("number");
+        Injector injector = Injector.create(field, "setNumber", "num");
+
+        assertThat(injector).isNotNull();
+        assertThat(injector.getUniqueFieldName()).isEqualTo("num");
+    }
+}


### PR DESCRIPTION
## Summary
- test that unique field name is preserved for field-based injection
- test that unique field name is preserved for method-based injection
- document new tests in `changelog.md`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685377c868f4832a899f80a3322a2f18