### PR TITLE
Fix Injector method lookup

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 * RecordFactory now checks the Java version before using records
 * Fixed VarHandle injection using a MethodHandle
 * Fixed VarHandle injection invocation for reflection-based Injector
+* Fixed Injector method-based creation to correctly locate void setters
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/main/java/com/cedarsoftware/io/reflect/Injector.java
+++ b/src/main/java/com/cedarsoftware/io/reflect/Injector.java
@@ -172,7 +172,7 @@ public class Injector {
     public static Injector create(Field field, String methodName, String uniqueFieldName) {
         // find method that returns void
         try {
-            MethodType methodType = MethodType.methodType(Void.class, field.getType());
+            MethodType methodType = MethodType.methodType(void.class, field.getType());
             MethodHandle handle = MethodHandles.publicLookup().findVirtual(field.getDeclaringClass(), methodName, methodType);
             return new Injector(field, handle, uniqueFieldName, methodName);
         } catch (NoSuchMethodException | IllegalAccessException ex) {


### PR DESCRIPTION
## Summary
- use `void.class` when finding setter method
- document bug fix in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68537ac90c98832abd1d6a1cb9915a4b