### PR TITLE
Add tests for SealableMap utilities

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 * RecordFactory now checks the Java version before using records
 * Fixed VarHandle injection using a MethodHandle
 * Fixed VarHandle injection invocation for reflection-based Injector
+* Added tests for SealableMap's map constructor and methods
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/util/SealableMapTest.java
+++ b/src/test/java/com/cedarsoftware/io/util/SealableMapTest.java
@@ -2,6 +2,7 @@ package com.cedarsoftware.io.util;
 
 import java.util.AbstractMap;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -172,5 +173,33 @@ class SealableMapTest {
     void testNullValue() {
         map.put("99", null);
         assert map.get("99") == null;
+    }
+
+    @Test
+    void testConstructorWithMap() {
+        Map<String, Integer> backing = new LinkedHashMap<>();
+        backing.put("alpha", 1);
+        SealableMap<String, Integer> local = new SealableMap<>(backing, sealedSupplier);
+        assertEquals(1, local.get("alpha"));
+        backing.put("beta", 2);
+        assertEquals(2, local.get("beta"));
+        local.put("gamma", 3);
+        assertEquals(Integer.valueOf(3), backing.get("gamma"));
+    }
+
+    @Test
+    void testContainsValueAndToString() {
+        assertTrue(map.containsValue(2));
+        assertTrue(map.containsValue(null));
+        assertTrue(map.toString().contains("one"));
+    }
+
+    @Test
+    void testHashCodeMatchesBackingMap() {
+        Map<String, Integer> backing = new LinkedHashMap<>();
+        backing.put("a", 1);
+        backing.put("b", 2);
+        SealableMap<String, Integer> local = new SealableMap<>(backing, sealedSupplier);
+        assertEquals(backing.hashCode(), local.hashCode());
     }
 }


### PR DESCRIPTION
## Summary
- verify SealableMap(Map, Supplier) constructor
- test containsValue, toString and hashCode methods
- document added tests in changelog

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68537b2859f8832abc611aecee058273