### PR TITLE
Fix Injector method creation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 * Fixed VarHandle injection using a MethodHandle
 * Fixed VarHandle injection invocation for reflection-based Injector
 * Fixed Injector method-based creation to correctly locate void setters
+* Injector.create now supports invoking package-private and private setter methods
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/main/java/com/cedarsoftware/io/reflect/Injector.java
+++ b/src/main/java/com/cedarsoftware/io/reflect/Injector.java
@@ -170,12 +170,19 @@ public class Injector {
     }
 
     public static Injector create(Field field, String methodName, String uniqueFieldName) {
-        // find method that returns void
         try {
-            MethodType methodType = MethodType.methodType(void.class, field.getType());
-            MethodHandle handle = MethodHandles.publicLookup().findVirtual(field.getDeclaringClass(), methodName, methodType);
+            Method method = field.getDeclaringClass().getDeclaredMethod(methodName, field.getType());
+            if (!method.isAccessible()) {
+                try {
+                    method.setAccessible(true);
+                } catch (Exception e) {
+                    return null;
+                }
+            }
+
+            MethodHandle handle = MethodHandles.lookup().unreflect(method);
             return new Injector(field, handle, uniqueFieldName, methodName);
-        } catch (NoSuchMethodException | IllegalAccessException ex) {
+        } catch (NoSuchMethodException | IllegalAccessException e) {
             return null;
         }
     }


### PR DESCRIPTION
## Summary
- allow Injector to create method handles for non-public setters
- note support for private/package-private setters

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68537bd9cad8832abdaa2bf0550298af