### PR TITLE
Fix Injector method-based creation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 * Fixed VarHandle injection using a MethodHandle
 * Fixed VarHandle injection invocation for reflection-based Injector
 * Fixed Injector method-based creation to correctly locate void setters
+* Injector method-based creation now works with package-private setters
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/main/java/com/cedarsoftware/io/reflect/Injector.java
+++ b/src/main/java/com/cedarsoftware/io/reflect/Injector.java
@@ -176,7 +176,7 @@ public class Injector {
         // find method that returns void
         try {
             MethodType methodType = MethodType.methodType(void.class, field.getType());
-            MethodHandle handle = MethodHandles.publicLookup().findVirtual(field.getDeclaringClass(), methodName, methodType);
+            MethodHandle handle = MethodHandles.lookup().findVirtual(field.getDeclaringClass(), methodName, methodType);
             return new Injector(field, handle, uniqueFieldName, methodName);
         } catch (NoSuchMethodException | IllegalAccessException ex) {
             return null;


### PR DESCRIPTION
## Summary
- fix method handle lookup to allow package-private setters
- document change

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68537db65a88832a914f5b0330027e0b