### PR TITLE
Add constructor tests for SealableNavigableSet

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
 * Fixed Injector method-based creation to correctly locate void setters
 * Injector.create now supports invoking package-private and private setter methods
 * Added tests for SealableNavigableMap.equals(), toString(), and descendingKeySet()
+* Added tests for SealableNavigableSet constructors
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/util/SealableNavigableSetConstructorTest.java
+++ b/src/test/java/com/cedarsoftware/io/util/SealableNavigableSetConstructorTest.java
@@ -1,0 +1,60 @@
+package com.cedarsoftware.io.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SealableNavigableSetConstructorTest {
+
+    private volatile boolean sealed;
+    private Supplier<Boolean> sealedSupplier;
+
+    @BeforeEach
+    void setUp() {
+        sealed = false;
+        sealedSupplier = () -> sealed;
+    }
+
+    @Test
+    void testComparatorConstructor() {
+        Comparator<Integer> desc = Comparator.reverseOrder();
+        SealableNavigableSet<Integer> set = new SealableNavigableSet<>(desc, sealedSupplier);
+        set.addAll(Arrays.asList(1, 2, 3));
+
+        assertSame(desc, set.comparator());
+        assertEquals(Integer.valueOf(3), set.first());
+        assertEquals(Integer.valueOf(1), set.last());
+    }
+
+    @Test
+    void testCollectionConstructor() {
+        Collection<Integer> source = new ArrayList<>(Arrays.asList(1, 2, 3));
+        SealableNavigableSet<Integer> set = new SealableNavigableSet<>(source, sealedSupplier);
+        source.add(4);
+
+        assertEquals(3, set.size());
+        assertTrue(set.containsAll(Arrays.asList(1, 2, 3)));
+        assertFalse(set.contains(4));
+    }
+
+    @Test
+    void testSortedSetConstructor() {
+        SortedSet<Integer> backing = new TreeSet<>(Comparator.reverseOrder());
+        backing.addAll(Arrays.asList(1, 2, 3));
+        SealableNavigableSet<Integer> set = new SealableNavigableSet<>(backing, sealedSupplier);
+        backing.add(4);
+
+        assertEquals(3, set.size());
+        assertFalse(set.contains(4));
+        assertSame(backing.comparator(), set.comparator());
+    }
+}


### PR DESCRIPTION
## Summary
- cover additional SealableNavigableSet constructors
- document test addition in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68537fad8824832a9595a13acc124266