### PR TITLE
Fix SortedSet comparator handling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * Fixed deserialization of Java records
 * Tests now create record classes via reflection for JDK 8 compatibility
 * SealableNavigableMap now wraps returned entries to enforce immutability
+* Preserve comparator when constructing `SealableNavigableSet` from a `SortedSet`
 * Documentation expanded for CompactMap usage and builder() caveats
 * JsonObject exposes `getTypeString()` with the raw `@type` value
 * Added tests for ModifierMaskFilter.

--- a/src/main/java/com/cedarsoftware/io/util/SealableNavigableSet.java
+++ b/src/main/java/com/cedarsoftware/io/util/SealableNavigableSet.java
@@ -84,7 +84,8 @@ public class SealableNavigableSet<E> implements NavigableSet<E> {
      */
     public SealableNavigableSet(SortedSet<E> set, Supplier<Boolean> sealedSupplier) {
         this.sealedSupplier = sealedSupplier;
-        navSet = new ConcurrentNavigableSetNullSafe<>(set);
+        navSet = new ConcurrentNavigableSetNullSafe<>(set.comparator());
+        navSet.addAll(set);
     }
 
     /**


### PR DESCRIPTION
## Summary
- preserve comparator in SealableNavigableSet SortedSet constructor
- document change in changelog

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685383607fa0832a9ca2b88c59f65f8c