### PR TITLE
Fix SealableSet copy constructor

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
 * Fixed VarHandle injection invocation for reflection-based Injector
 * Fixed Injector method-based creation to correctly locate void setters
 * Injector.create now supports invoking package-private and private setter methods
+* SealableSet(Collection) now copies the supplied collection instead of wrapping it
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/main/java/com/cedarsoftware/io/util/SealableSet.java
+++ b/src/main/java/com/cedarsoftware/io/util/SealableSet.java
@@ -55,7 +55,8 @@ public class SealableSet<T> implements Set<T> {
      */
     public SealableSet(Collection<T> col, Supplier<Boolean> sealedSupplier) {
         this.sealedSupplier = sealedSupplier;
-        this.set = new ConcurrentSet<>(col);
+        this.set = new ConcurrentSet<>();
+        this.set.addAll(col);
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure SealableSet(Collection) copies source collection
- document the fix in changelog

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685383827090832a834cc9295fba9e69