### PR TITLE
Fix addAll modification return

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 * Added tests for ModifierMaskFilter.
 * Pinned core Maven plugin versions to prevent Maven 4 warnings
 * Fixed SealableNavigableSet.retainAll to correctly return modification status
+* Fixed SealableNavigableSet.addAll to report modifications
 * Documentation updated with guidance for parsing JSON that references unknown classes
 * RecordFactory now uses java-util `ReflectionUtils`
 * Added RecordReader test

--- a/src/main/java/com/cedarsoftware/io/util/SealableNavigableSet.java
+++ b/src/main/java/com/cedarsoftware/io/util/SealableNavigableSet.java
@@ -153,7 +153,16 @@ public class SealableNavigableSet<E> implements NavigableSet<E> {
 
     // Mutable APIs
     public boolean add(E e) { throwIfSealed(); return navSet.add(e); }
-    public boolean addAll(Collection<? extends E> col) { throwIfSealed(); return navSet.addAll(col); }
+    public boolean addAll(Collection<? extends E> col) {
+        throwIfSealed();
+        boolean modified = false;
+        for (E e : col) {
+            if (navSet.add(e)) {
+                modified = true;
+            }
+        }
+        return modified;
+    }
     public void clear() { throwIfSealed(); navSet.clear(); }
     public boolean remove(Object o) { throwIfSealed(); return navSet.remove(o); }
     public boolean removeAll(Collection<?> col) { throwIfSealed(); return navSet.removeAll(col); }


### PR DESCRIPTION
## Summary
- ensure `SealableNavigableSet.addAll` returns true when it adds any element
- document change in `changelog.md`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685386476118832a9c07e993b21f582a