### PR TITLE
Fix SealableSet copy test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 * Fixed Injector method-based creation to correctly locate void setters
 * Injector.create now supports invoking package-private and private setter methods
 * SealableSet(Collection) now copies the supplied collection instead of wrapping it
+* Fixed tests to call the correct SealableSet constructor
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/util/SealableSetAdditionalTest.java
+++ b/src/test/java/com/cedarsoftware/io/util/SealableSetAdditionalTest.java
@@ -11,7 +11,7 @@ class SealableSetAdditionalTest {
 
     @Test
     void testCollectionConstructorMakesCopy() {
-        Set<Integer> source = new LinkedHashSet<>(Arrays.asList(1, 2, 3));
+        Collection<Integer> source = new LinkedHashSet<>(Arrays.asList(1, 2, 3));
         Supplier<Boolean> sealedSupplier = () -> false;
         SealableSet<Integer> copy = new SealableSet<>(source, sealedSupplier);
         source.add(4);


### PR DESCRIPTION
## Summary
- correct collection constructor test for SealableSet
- note test fix in changelog

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6853867ec588832a830fec57a1782358