### PR TITLE
Add SealableNavigableSet unit tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,8 @@
 * Fixed Injector method-based creation to correctly locate void setters
 * Injector.create now supports invoking package-private and private setter methods
 * SealableSet(Collection) now copies the supplied collection instead of wrapping it
+* Added unit tests for `SealableNavigableSet` covering `equals()`, `toString()`,
+  `pollFirst()` and `pollLast()`
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/util/SealableNavigableSetAdditionalTest.java
+++ b/src/test/java/com/cedarsoftware/io/util/SealableNavigableSetAdditionalTest.java
@@ -139,4 +139,34 @@ class SealableNavigableSetAdditionalTest {
         sealed = true;
         assertThrows(UnsupportedOperationException.class, it::remove);
     }
+
+    @Test
+    void testEquals() {
+        SealableNavigableSet<Integer> other = new SealableNavigableSet<>(sealedSupplier);
+        other.addAll(asList(10, 20, 30));
+        assertEquals(set, other);
+        other.add(40);
+        assertNotEquals(set, other);
+    }
+
+    @Test
+    void testToStringReflectsSetContents() {
+        NavigableSet<Integer> expected = new TreeSet<>(asList(10, 20, 30));
+        assertEquals(expected.toString(), set.toString());
+        set.add(40);
+        expected.add(40);
+        assertEquals(expected.toString(), set.toString());
+    }
+
+    @Test
+    void testPollFirstAndLast() {
+        assertEquals(Integer.valueOf(10), set.pollFirst());
+        assertEquals(Integer.valueOf(30), set.pollLast());
+        assertFalse(set.contains(10));
+        assertFalse(set.contains(30));
+
+        set.clear();
+        assertNull(set.pollFirst());
+        assertNull(set.pollLast());
+    }
 }


### PR DESCRIPTION
## Summary
- add equals, toString and pollFirst/Last tests for `SealableNavigableSet`
- document the new tests in `changelog.md`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685386dbc654832aaeda5b69c6dbe4a1