### PR TITLE
Fix retainAll assertion

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * Pinned core Maven plugin versions to prevent Maven 4 warnings
 * Fixed SealableNavigableSet.retainAll to correctly return modification status
 * Fixed SealableNavigableSet.addAll to report modifications
+* Corrected assertion for `retainAll` result in `SealableNavigableSetAdditionalTest`
 * Documentation updated with guidance for parsing JSON that references unknown classes
 * RecordFactory now uses java-util `ReflectionUtils`
 * Added RecordReader test

--- a/src/test/java/com/cedarsoftware/io/util/SealableNavigableSetAdditionalTest.java
+++ b/src/test/java/com/cedarsoftware/io/util/SealableNavigableSetAdditionalTest.java
@@ -97,7 +97,7 @@ class SealableNavigableSetAdditionalTest {
         assertTrue(set.addAll(asList(40, 50)));
         assertTrue(set.remove(Integer.valueOf(20)));
         assertTrue(set.removeAll(asList(10)));
-        assertTrue(set.retainAll(asList(30, 40, 50)));
+        assertFalse(set.retainAll(asList(30, 40, 50)));
         assertEquals(Integer.valueOf(30), set.pollFirst());
         assertEquals(Integer.valueOf(50), set.pollLast());
         set.clear();


### PR DESCRIPTION
## Summary
- correct retainAll result check in SealableNavigableSetAdditionalTest
- note the correction in `changelog.md`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853891232e0832abb1986d3a5604188