### PR TITLE
Add ByteArrayWriter unit tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@
 * Fixed Injector method-based creation to correctly locate void setters
 * Injector.create now supports invoking package-private and private setter methods
 * SealableSet(Collection) now copies the supplied collection instead of wrapping it
+* Added tests for ByteArrayWriter
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/writers/ByteArrayWriterTest.java
+++ b/src/test/java/com/cedarsoftware/io/writers/ByteArrayWriterTest.java
@@ -1,0 +1,27 @@
+package com.cedarsoftware.io.writers;
+
+import java.io.StringWriter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ByteArrayWriterTest {
+
+    @Test
+    void writesBase64EncodedPrimitiveForm() throws Exception {
+        ByteArrayWriter writer = new ByteArrayWriter();
+        StringWriter out = new StringWriter();
+        byte[] bytes = {1, 2, 3, 4};
+
+        writer.writePrimitiveForm(bytes, out, null);
+
+        assertThat(out.toString()).isEqualTo("\"AQIDBA==\"");
+    }
+
+    @Test
+    void hasPrimitiveFormAlwaysTrue() {
+        ByteArrayWriter writer = new ByteArrayWriter();
+        assertThat(writer.hasPrimitiveForm(null)).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- add a new test to cover ByteArrayWriter
- document ByteArrayWriter test in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68538b080d14832ab22e22610eab6b0b