### PR TITLE
Add ByteBufferWriter tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@
 * Expanded `SingletonList` tests for branch coverage
 * Fixed VarHandle reflection to allow private-constructor injector
 * Added unit tests for `SingletonMap` covering initialization, view collections, and equality
+* Added tests for `ByteBufferWriter` covering array and direct buffers
 * RecordFactory now checks the Java version before using records
 * Fixed VarHandle injection using a MethodHandle
 * Fixed VarHandle injection invocation for reflection-based Injector

--- a/src/test/java/com/cedarsoftware/io/writers/ByteBufferWriterTest.java
+++ b/src/test/java/com/cedarsoftware/io/writers/ByteBufferWriterTest.java
@@ -1,0 +1,45 @@
+package com.cedarsoftware.io.writers;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ByteBufferWriterTest {
+
+    @Test
+    void writesArrayBackedBuffer() throws IOException {
+        byte[] data = {1, 2, 3, 4, 5};
+        ByteBuffer buffer = ByteBuffer.wrap(data);
+        buffer.position(1);
+        buffer.limit(4);
+        int originalPosition = buffer.position();
+
+        StringWriter out = new StringWriter();
+        new ByteBufferWriter().write(buffer, false, out, null);
+
+        String expected = "\"value\":\"" + Base64.getEncoder().encodeToString(new byte[]{2, 3, 4}) + "\"";
+        assertEquals(expected, out.toString());
+        assertEquals(originalPosition, buffer.position());
+    }
+
+    @Test
+    void writesDirectBufferAndRestoresPosition() throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(5);
+        buffer.put(new byte[]{10, 20, 30, 40, 50});
+        buffer.position(1);
+        buffer.limit(4);
+        int originalPosition = buffer.position();
+
+        StringWriter out = new StringWriter();
+        new ByteBufferWriter().write(buffer, true, out, null);
+
+        String expected = "\"value\":\"" + Base64.getEncoder().encodeToString(new byte[]{20, 30, 40}) + "\"";
+        assertEquals(expected, out.toString());
+        assertEquals(originalPosition, buffer.position());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for `ByteBufferWriter`
- document new tests in `changelog.md`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68538b31f15c832a89946f31a2c1128b