### PR TITLE
Add CharBufferWriter tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@
 * Fixed Injector method-based creation to correctly locate void setters
 * Injector.create now supports invoking package-private and private setter methods
 * SealableSet(Collection) now copies the supplied collection instead of wrapping it
+* Added unit tests for CharBufferWriter.
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/writers/CharBufferWriterTest.java
+++ b/src/test/java/com/cedarsoftware/io/writers/CharBufferWriterTest.java
@@ -1,0 +1,41 @@
+package com.cedarsoftware.io.writers;
+
+import java.io.StringWriter;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CharBufferWriterTest {
+
+    @Test
+    void testWriteArrayBackedBufferEscaping() throws Exception {
+        char[] data = new char[]{'X', 'a', '"', '\\', '\b', '\f', '\n', '\r', '\t', 0x12, 'Y'};
+        CharBuffer buffer = CharBuffer.wrap(data);
+        buffer.position(1);
+        buffer.limit(data.length - 1);
+        StringWriter out = new StringWriter();
+
+        new CharBufferWriter().write(buffer, false, out, null);
+
+        assertEquals("\"value\":\"a\\\"\\\\\\b\\f\\n\\r\\t\\u0012\"", out.toString());
+        assertEquals(1, buffer.position());
+    }
+
+    @Test
+    void testWriteNonArrayBackedBufferRestoresPosition() throws Exception {
+        ByteBuffer bytes = ByteBuffer.allocateDirect(8);
+        CharBuffer buffer = bytes.asCharBuffer();
+        buffer.put("abc");
+        buffer.flip();
+        buffer.position(1);
+        StringWriter out = new StringWriter();
+
+        new CharBufferWriter().write(buffer, false, out, null);
+
+        assertEquals("\"value\":\"bc\"", out.toString());
+        assertEquals(1, buffer.position());
+    }
+}


### PR DESCRIPTION
## Summary
- add tests covering `CharBufferWriter` for array-backed and direct buffers
- document the new tests in `changelog.md`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68538b60f158832a9734d053f6dabd38