### PR TITLE
Add tests for ArgumentHelper

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@
 * Injector.create now supports invoking package-private and private setter methods
 * SealableSet(Collection) now copies the supplied collection instead of wrapping it
 * Added unit tests for CharBufferWriter.
+* Added tests for `ArgumentHelper.getNumberWithDefault`.
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/ArgumentHelperTest.java
+++ b/src/test/java/com/cedarsoftware/io/ArgumentHelperTest.java
@@ -4,11 +4,13 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ArgumentHelperTest
 {
@@ -64,6 +66,26 @@ class ArgumentHelperTest
                 Arguments.of(0),
                 Arguments.of(0L),
                 Arguments.of(Byte.valueOf((byte)0)))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("numberWithDefaultValues")
+    void getNumberWithDefault_validInput_returnsExpected(Object input, Number def, Number expected) {
+        assertThat(ArgumentHelper.getNumberWithDefault(input, def)).isEqualTo(expected);
+    }
+
+    @Test
+    void getNumberWithDefault_nonNumber_throwsClassCastException() {
+        assertThatThrownBy(() -> ArgumentHelper.getNumberWithDefault("foo", 1))
+                .isInstanceOf(ClassCastException.class);
+    }
+
+    private static Stream<Arguments> numberWithDefaultValues() {
+        return Stream.of(
+                Arguments.of(null, 42, 42),
+                Arguments.of(Integer.valueOf(5), 9, Integer.valueOf(5)),
+                Arguments.of(3.14d, 0, 3.14d)
         );
     }
 }


### PR DESCRIPTION
## Summary
- add JUnit tests for ArgumentHelper.getNumberWithDefault
- document the new tests in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68538cf4bb64832ab728cec5afa3d8e0