### PR TITLE
Add unit test for JsonIo.main output

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@
 * Injector.create now supports invoking package-private and private setter methods
 * SealableSet(Collection) now copies the supplied collection instead of wrapping it
 * Added unit tests for CharBufferWriter.
+* Added unit test for `JsonIo.main()` output of supported conversions.
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/JsonIoMainTest.java
+++ b/src/test/java/com/cedarsoftware/io/JsonIoMainTest.java
@@ -1,0 +1,30 @@
+package com.cedarsoftware.io;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the {@link JsonIo#main(String[])} method.
+ */
+class JsonIoMainTest {
+    @Test
+    void verifyMainOutputsSupportedConversions() {
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(baos));
+        try {
+            JsonIo.main(new String[0]);
+        } finally {
+            System.setOut(originalOut);
+        }
+        String output = baos.toString(StandardCharsets.UTF_8);
+        assertTrue(output.contains("json-io supported conversions"));
+        assertTrue(output.contains("java.lang.String"));
+        assertTrue(output.contains("java.lang.Integer"));
+    }
+}


### PR DESCRIPTION
## Summary
- add JsonIoMainTest to assert output from JsonIo.main()
- log new test in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68538dbfe29c832a80ea5b356c5afc1c