### PR TITLE
Fix JDK 8 test compatibility

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 * Fixed SealableNavigableSet.retainAll to correctly return modification status
 * Fixed SealableNavigableSet.addAll to report modifications
 * Corrected assertion for `retainAll` result in `SealableNavigableSetAdditionalTest`
+* Tests avoid `ByteArrayOutputStream.toString(Charset)` for JDK 8 compatibility
 * Documentation updated with guidance for parsing JSON that references unknown classes
 * RecordFactory now uses java-util `ReflectionUtils`
 * Added RecordReader test

--- a/src/test/java/com/cedarsoftware/io/JsonIoMainTest.java
+++ b/src/test/java/com/cedarsoftware/io/JsonIoMainTest.java
@@ -22,7 +22,9 @@ class JsonIoMainTest {
         } finally {
             System.setOut(originalOut);
         }
-        String output = baos.toString(StandardCharsets.UTF_8);
+        // JDK 10 added ByteArrayOutputStream.toString(Charset), so use the
+        // older constructor to remain compatible with JDK 8.
+        String output = new String(baos.toByteArray(), StandardCharsets.UTF_8);
         assertTrue(output.contains("json-io supported conversions"));
         assertTrue(output.contains("java.lang.String"));
         assertTrue(output.contains("java.lang.Integer"));


### PR DESCRIPTION
## Summary
- avoid ByteArrayOutputStream.toString(Charset) in JsonIoMainTest
- note JDK 8 compatibility fix in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68538fcf4428832aa4c992b7ad4769f5