### PR TITLE
Add tests for parser cache entry sets

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,7 @@
 * Fixed Injector method-based creation to correctly locate void setters
 * Injector.create now supports invoking package-private and private setter methods
 * SealableSet(Collection) now copies the supplied collection instead of wrapping it
+* Added tests for JsonParser caches entrySet() methods
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/ParserCachesEntrySetTest.java
+++ b/src/test/java/com/cedarsoftware/io/ParserCachesEntrySetTest.java
@@ -1,0 +1,56 @@
+package com.cedarsoftware.io;
+
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ParserCachesEntrySetTest {
+
+    @Test
+    void testParserStringCacheEntrySet() throws Exception {
+        Map<String, String> staticCache = new HashMap<>();
+        staticCache.put("a", "A");
+        staticCache.put("b", "B");
+
+        Class<?> cls = Class.forName("com.cedarsoftware.io.JsonParser$ParserStringCache");
+        Constructor<?> ctor = cls.getDeclaredConstructor(Map.class);
+        ctor.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, String> cache = (Map<String, String>) ctor.newInstance(staticCache);
+
+        cache.put("c", "C");
+        Set<Map.Entry<String, String>> entries = cache.entrySet();
+
+        assertEquals(3, entries.size());
+        assertTrue(entries.stream().anyMatch(e -> "a".equals(e.getKey()) && "A".equals(e.getValue())));
+        assertTrue(entries.stream().anyMatch(e -> "b".equals(e.getKey()) && "B".equals(e.getValue())));
+        assertTrue(entries.stream().anyMatch(e -> "c".equals(e.getKey()) && "C".equals(e.getValue())));
+    }
+
+    @Test
+    void testParserNumberCacheEntrySet() throws Exception {
+        Map<Number, Number> staticCache = new HashMap<>();
+        staticCache.put(1, 1);
+        staticCache.put(2, 2);
+
+        Class<?> cls = Class.forName("com.cedarsoftware.io.JsonParser$ParserNumberCache");
+        Constructor<?> ctor = cls.getDeclaredConstructor(Map.class);
+        ctor.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<Number, Number> cache = (Map<Number, Number>) ctor.newInstance(staticCache);
+
+        cache.put(3, 3);
+        Set<Map.Entry<Number, Number>> entries = cache.entrySet();
+
+        assertEquals(3, entries.size());
+        assertTrue(entries.stream().anyMatch(e -> e.getKey().equals(1) && e.getValue().equals(1)));
+        assertTrue(entries.stream().anyMatch(e -> e.getKey().equals(2) && e.getValue().equals(2)));
+        assertTrue(entries.stream().anyMatch(e -> e.getKey().equals(3) && e.getValue().equals(3)));
+    }
+}


### PR DESCRIPTION
## Summary
- test entrySet for JsonParser cache wrappers
- document new tests in changelog

## Testing
- `mvn -q test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685391abfae4832aacd78d8a31a6676c