### PR TITLE
Add default method tests for JsonReader

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@
 * Fixed VarHandle injection invocation for reflection-based Injector
 * Fixed Injector method-based creation to correctly locate void setters
 * Injector.create now supports invoking package-private and private setter methods
+* Added tests for JsonReader default methods
 * SealableSet(Collection) now copies the supplied collection instead of wrapping it
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`

--- a/src/test/java/com/cedarsoftware/io/JsonReaderDefaultMethodsTest.java
+++ b/src/test/java/com/cedarsoftware/io/JsonReaderDefaultMethodsTest.java
@@ -1,0 +1,33 @@
+package com.cedarsoftware.io;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for JsonReader interface default methods.
+ */
+public class JsonReaderDefaultMethodsTest {
+
+    static class Sample {}
+
+    @Test
+    void classFactoryDefaultNewInstanceReturnsObject() {
+        JsonReader.ClassFactory factory = new JsonReader.ClassFactory() {};
+        JsonReader reader = new JsonReader(ReadOptionsBuilder.getDefaultReadOptions());
+
+        Object instance = factory.newInstance(Sample.class, null, reader.getResolver());
+
+        assertTrue(instance instanceof Sample);
+    }
+
+    @Test
+    void jsonClassReaderReadThrowsByDefault() {
+        JsonReader.JsonClassReader classReader = new JsonReader.JsonClassReader() {};
+        JsonReader reader = new JsonReader(ReadOptionsBuilder.getDefaultReadOptions());
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> classReader.read(new JsonObject(), reader.getResolver()));
+    }
+}


### PR DESCRIPTION
## Summary
- add `JsonReaderDefaultMethodsTest` verifying interface defaults
- document new tests in `changelog.md`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685392c80488832a86ba14d0434b4509