### PR TITLE
Add unit test for DefaultReferenceTracker size

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,7 @@
 * Added tests for JsonReader default methods
 * SealableSet(Collection) now copies the supplied collection instead of wrapping it
 * Added unit test for Unicode surrogate pair escapes
+* Added test for `DefaultReferenceTracker.size()`
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/DefaultReferenceTrackerTest.java
+++ b/src/test/java/com/cedarsoftware/io/DefaultReferenceTrackerTest.java
@@ -1,0 +1,27 @@
+package com.cedarsoftware.io;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for JsonReader.DefaultReferenceTracker.
+ */
+class DefaultReferenceTrackerTest {
+
+    @Test
+    void sizeReturnsNumberOfTrackedReferences() {
+        JsonReader.DefaultReferenceTracker tracker = new JsonReader.DefaultReferenceTracker();
+
+        assertEquals(0, tracker.size());
+
+        tracker.put(1L, new JsonObject());
+        assertEquals(1, tracker.size());
+
+        tracker.put(2L, new JsonObject());
+        assertEquals(2, tracker.size());
+
+        tracker.clear();
+        assertEquals(0, tracker.size());
+    }
+}


### PR DESCRIPTION
## Summary
- add DefaultReferenceTrackerTest verifying `size()` counts references
- document the test in the changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68539513a45c832aa179d7e0bb92631c