### PR TITLE
Add tests for JsonWriter value reflection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,7 @@
 * Added tests for JsonReader default methods
 * SealableSet(Collection) now copies the supplied collection instead of wrapping it
 * Added unit test for Unicode surrogate pair escapes
+* Added unit tests for `JsonWriter.getValueByReflect`
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/JsonWriterGetValueByReflectTest.java
+++ b/src/test/java/com/cedarsoftware/io/JsonWriterGetValueByReflectTest.java
@@ -1,0 +1,60 @@
+package com.cedarsoftware.io;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import com.cedarsoftware.util.FastByteArrayOutputStream;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class JsonWriterGetValueByReflectTest {
+
+    static class PublicHolder {
+        public String text = "hello";
+    }
+
+    static class PrivateHolder {
+        private int number = 42;
+    }
+
+    static class StaticHolder {
+        public static final String CONST = "static";
+    }
+
+    @Test
+    void testReadPublicField() throws Exception {
+        JsonWriter writer = new JsonWriter(new FastByteArrayOutputStream());
+        Method m = JsonWriter.class.getDeclaredMethod("getValueByReflect", Object.class, Field.class);
+        m.setAccessible(true);
+
+        PublicHolder holder = new PublicHolder();
+        Field f = PublicHolder.class.getField("text");
+        Object result = m.invoke(writer, holder, f);
+        assertEquals("hello", result);
+    }
+
+    @Test
+    void testReadPrivateField_returnsNull() throws Exception {
+        JsonWriter writer = new JsonWriter(new FastByteArrayOutputStream());
+        Method m = JsonWriter.class.getDeclaredMethod("getValueByReflect", Object.class, Field.class);
+        m.setAccessible(true);
+
+        PrivateHolder holder = new PrivateHolder();
+        Field f = PrivateHolder.class.getDeclaredField("number");
+        Object result = m.invoke(writer, holder, f);
+        assertNull(result);
+    }
+
+    @Test
+    void testReadStaticFieldWithNullObject() throws Exception {
+        JsonWriter writer = new JsonWriter(new FastByteArrayOutputStream());
+        Method m = JsonWriter.class.getDeclaredMethod("getValueByReflect", Object.class, Field.class);
+        m.setAccessible(true);
+
+        Field f = StaticHolder.class.getDeclaredField("CONST");
+        Object result = m.invoke(writer, null, f);
+        assertEquals("static", result);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for `JsonWriter.getValueByReflect`
- document change in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685395ca59bc832a9170d3606c25cab4