### PR TITLE
Add tests for ObjectResolver.safeToString

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,7 @@
 * Added tests for JsonReader default methods
 * SealableSet(Collection) now copies the supplied collection instead of wrapping it
 * Added unit test for Unicode surrogate pair escapes
+* Added tests for ObjectResolver.safeToString
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/ObjectResolverMethodsTest.java
+++ b/src/test/java/com/cedarsoftware/io/ObjectResolverMethodsTest.java
@@ -1,0 +1,42 @@
+package com.cedarsoftware.io;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ObjectResolverMethodsTest {
+
+    @Test
+    void safeToString_null_returnsNull() throws Exception {
+        Method m = ObjectResolver.class.getDeclaredMethod("safeToString", Object.class);
+        m.setAccessible(true);
+        String result = (String) m.invoke(null, (Object) null);
+        assertEquals("null", result);
+    }
+
+    @Test
+    void safeToString_validObject_returnsToString() throws Exception {
+        Method m = ObjectResolver.class.getDeclaredMethod("safeToString", Object.class);
+        m.setAccessible(true);
+        String result = (String) m.invoke(null, "foo");
+        assertEquals("foo", result);
+    }
+
+    private static class BadToString {
+        @Override
+        public String toString() {
+            throw new RuntimeException("bad");
+        }
+    }
+
+    @Test
+    void safeToString_whenToStringThrows_returnsClassName() throws Exception {
+        Method m = ObjectResolver.class.getDeclaredMethod("safeToString", Object.class);
+        m.setAccessible(true);
+        BadToString obj = new BadToString();
+        String result = (String) m.invoke(null, obj);
+        assertEquals(obj.getClass().toString(), result);
+    }
+}


### PR DESCRIPTION
## Summary
- add ObjectResolverMethodsTest to verify safeToString
- document new test in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685396467378832a9f9ea9e79a133cd6