### PR TITLE
Fix NamedMethodFilter test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
 * RecordFactory now uses java-util `ReflectionUtils`
 * Added RecordReader test
 * Added tests for WriteOptionsBuilder features
+* Fixed NamedMethodFilter test by making Example class public
 * Added NamedMethodFilter tests and null-safe handling
 * Added tests for Injector's private constructors
 * Fixed `SealableNavigableSet.tailSet(E)` to include the starting element

--- a/src/test/java/com/cedarsoftware/io/WriteOptionsBuilderTest.java
+++ b/src/test/java/com/cedarsoftware/io/WriteOptionsBuilderTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class WriteOptionsBuilderTest {
 
-    static class Example {
+    public static class Example {
         public int value;
         public int getValue() { return value; }
     }


### PR DESCRIPTION
## Summary
- make `Example` class public so DefaultMethodFilter doesn't remove its getter
- note test tweak in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68539c2952f4832a8c9c055518a1f1a8