### PR TITLE
Fix WriteOptionsBuilder method filter test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -37,6 +37,7 @@
 * Added unit test for Unicode surrogate pair escapes
 * Added tests for ObjectResolver.safeToString
 * Added tests for ReadOptionsBuilder configuration methods
+* Corrected Example visibility in WriteOptionsBuilder tests
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/WriteOptionsBuilderTest.java
+++ b/src/test/java/com/cedarsoftware/io/WriteOptionsBuilderTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class WriteOptionsBuilderTest {
 
-    static class Example {
+    public static class Example {
         public int value;
         public int getValue() { return value; }
     }


### PR DESCRIPTION
## Summary
- mark `Example` as public so default method filter doesn't exclude its getter
- note test fix in changelog

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68539c7edb44832a9d77d0d8c57c1d57