### PR TITLE
Fix enum writer root output

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.2` to `3.3.3.`
 * Fixed deserialization of Java records
 * Tests now create record classes via reflection for JDK 8 compatibility
+* Enums written as strings no longer include `@type` at the top level
 * SealableNavigableMap now wraps returned entries to enforce immutability
 * Preserve comparator when constructing `SealableNavigableSet` from a `SortedSet`
 * Documentation expanded for CompactMap usage and builder() caveats

--- a/src/main/java/com/cedarsoftware/io/JsonWriter.java
+++ b/src/main/java/com/cedarsoftware/io/JsonWriter.java
@@ -362,7 +362,18 @@ public class JsonWriter implements WriterContext, Closeable, Flushable
         traceReferences(obj);
         objVisited.clear();
         try {
-            writeImpl(obj, true);
+            boolean showType = true;
+            if (obj != null) {
+                if (writeOptions.isNeverShowingType()) {
+                    showType = false;
+                } else if (!writeOptions.isAlwaysShowingType()) {
+                    JsonClassWriter writer = writeOptions.getCustomWriter(obj.getClass());
+                    if (writer instanceof Writers.EnumsAsStringWriter) {
+                        showType = false;
+                    }
+                }
+            }
+            writeImpl(obj, showType);
         } catch (JsonIoException e) {
             throw e;
         } catch (Exception e) {

--- a/user-guide-writeOptions.md
+++ b/user-guide-writeOptions.md
@@ -252,6 +252,7 @@ Here's how you configure these options in `json-io`:
 
 >#### `WriteOptionsBuilder` writeEnumsAsString()
 >- [ ] Sets the option to write enums as a `String.` This is the default option.  If you have called `writeEnumAsJsonObject(true or false),` call `writeEnumsAsString()`to return to enum output as `String.`
+- [ ] Top-level enums written as strings omit `@type` metadata.
 >#### `WriteOptionsBuilder` writeEnumAsJsonObject(`boolean writePublicFieldsOnly`)
 >- [ ] Sets the option to write all the member fields of an enum, using JSON { } format for the enum, to allow for multiple fields. Setting this option to `true` or `false` (include/exclude private fields), turns off the writeEnumsAsString() option. This option is off by default - enums are written as `String` by default.
 >#### `WriteOptionsBuilder` writeEnumSetOldWay(`boolean writeEnumSetOldWay`)


### PR DESCRIPTION
## Summary
- ensure top-level enums written as strings do not show `@type`
- document the behavior in the write options guide
- mention the fix in the changelog

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68539c5243e4832aab2c5f7830a3f048