### PR TITLE
Fix write options builder side effects

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -40,6 +40,7 @@
 * Added tests for ObjectResolver.safeToString
 * Added tests for ReadOptionsBuilder configuration methods
 * Corrected Example visibility in WriteOptionsBuilder tests
+* Added APIs to remove permanent method filters and accessor factories
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/main/java/com/cedarsoftware/io/WriteOptionsBuilder.java
+++ b/src/main/java/com/cedarsoftware/io/WriteOptionsBuilder.java
@@ -288,6 +288,15 @@ public class WriteOptionsBuilder {
     }
 
     /**
+     * Remove a permanently registered MethodFilter from json-io.
+     *
+     * @param name String name of the MethodFilter to remove.
+     */
+    public static void removePermanentMethodFilter(String name) {
+        BASE_METHOD_FILTERS.remove(name);
+    }
+
+    /**
      * Add a MethodFilter that is JVM lifecycle scoped. All WriteOptions instances will contain this filter.
      * @param name String name of this particular method filter instance.
      * @param clazz class that contains the method to be filtered (can be derived class, with field defined on parent class).
@@ -309,6 +318,15 @@ public class WriteOptionsBuilder {
      */
     public static void addPermanentAccessorFactory(String name, AccessorFactory factory) {
         BASE_ACCESSOR_FACTORIES.put(name, factory);
+    }
+
+    /**
+     * Remove a permanently registered AccessorFactory from json-io.
+     *
+     * @param name String name of the AccessorFactory to remove.
+     */
+    public static void removePermanentAccessorFactory(String name) {
+        BASE_ACCESSOR_FACTORIES.remove(name);
     }
 
     /**
@@ -789,7 +807,11 @@ public class WriteOptionsBuilder {
      * @return {@link WriteOptionsBuilder} for chained access.
      */
     public WriteOptionsBuilder addAccessorFactory(String factoryName, AccessorFactory accessorFactory) {
-        options.accessorFactories.put(factoryName, accessorFactory);
+        Map<String, AccessorFactory> map = new LinkedHashMap<>();
+        map.put(factoryName, accessorFactory);
+        map.putAll(options.accessorFactories);
+        options.accessorFactories.clear();
+        options.accessorFactories.putAll(map);
         return this;
     }
 

--- a/src/test/java/com/cedarsoftware/io/WriteOptionsBuilderTest.java
+++ b/src/test/java/com/cedarsoftware/io/WriteOptionsBuilderTest.java
@@ -71,6 +71,8 @@ public class WriteOptionsBuilderTest {
 
         assertTrue(preMethod);
         assertFalse(postMethod);
+        // Remove the permanent filter to avoid side effects on other tests
+        WriteOptionsBuilder.removePermanentMethodFilter("test");
     }
 
     @Test

--- a/user-guide-writeOptions.md
+++ b/user-guide-writeOptions.md
@@ -864,6 +864,10 @@ To call the API, pass a unique name that is unique across all MethodFilters, the
 resides, and the name of the method.
 >#### WriteOptionsBuilder.addPermanentNamedMethodFilter(`String name, Class<?> clazz, String methodName`)
 
+### removePermanentMethodFilter
+Remove a permanently registered `MethodFilter` by its name.
+>#### WriteOptionsBuilder.removePermanentMethodFilter(`String name`)
+
 ### addPermanentAccessorFactory
 Add an `AccessorFactory` that is JVM lifecycle scoped.  All `WriteOptions` instances will contain this `AccessorFactory.`
 It is the job of an `AccessorFactory` to provide a possible method name for a particular field. `json-io` ships with
@@ -871,3 +875,7 @@ a `GetMethodAccessorFactory` and an `IsMethodAccessFactory.` These produce a pos
 When a field on a Java class is being accessed (read), and it cannot be obtained directly, then all `AccessoryFactory`
 instances will be consulted until an API can be used to read the field.
 >#### WriteOptionsBuilder.addPermanentAccessorFactory(`String name, AccessorFactory factory`)
+
+### removePermanentAccessorFactory
+Remove a permanently registered `AccessorFactory` by its name.
+>#### WriteOptionsBuilder.removePermanentAccessorFactory(`String name`)


### PR DESCRIPTION
## Summary
- allow removing permanent accessor factories and method filters
- ensure new accessor factories run before defaults
- avoid test contamination by cleaning up method filters
- document the new APIs
- note removal APIs in changelog

## Testing
- `javac -d /tmp/build @/tmp/sources.txt` *(fails: package com.cedarsoftware.util does not exist)*

------
https://chatgpt.com/codex/tasks/task_b_68539e6810ec832ab8e302de6dadf9d2