### PR TITLE
Fix enum deserialization helper

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * Preserve comparator when constructing `SealableNavigableSet` from a `SortedSet`
 * Documentation expanded for CompactMap usage and builder() caveats
 * JsonObject exposes `getTypeString()` with the raw `@type` value
+* Fixed TestUtil.serializeDeserialize to retain Enum type information
 * Added unit tests for `JsonObject` equality, hashing and helpers
 * Added tests for ModifierMaskFilter.
 * Added tests for `SealableSet` constructor, `toArray()` and `SealAwareEntry` equality.

--- a/src/test/java/com/cedarsoftware/io/TestUtil.java
+++ b/src/test/java/com/cedarsoftware/io/TestUtil.java
@@ -31,7 +31,9 @@ public class TestUtil {
 
     public static <T> T serializeDeserialize(T initial) {
         String json = toJson(initial);
-        return toObjects(json, null);
+        @SuppressWarnings("unchecked")
+        Class<T> root = initial == null ? null : (Class<T>) initial.getClass();
+        return toObjects(json, root);
     }
 
     public static <T> Object serializeDeserializeAsMaps(T initial) {


### PR DESCRIPTION
## Summary
- ensure `serializeDeserialize` passes the object's type
- document enum deserialization fix in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68539f334fa8832aaa6b23a3f5580046