### PR TITLE
Fix EnumWithValueField primitive test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 * Tests avoid `ByteArrayOutputStream.toString(Charset)` for JDK 8 compatibility
 * Documentation updated with guidance for parsing JSON that references unknown classes
 * RecordFactory now uses java-util `ReflectionUtils`
+* Fixed `EnumTests` to deserialize enums written as primitive strings by providing the root class
 * Added RecordReader test
 * Added tests for WriteOptionsBuilder features
 * Fixed NamedMethodFilter test by making Example class public

--- a/src/test/java/com/cedarsoftware/io/EnumTests.java
+++ b/src/test/java/com/cedarsoftware/io/EnumTests.java
@@ -312,7 +312,7 @@ class EnumTests {
     @EnumSource(EnumWithValueField.class)
     void testEnum_thatHasValueField_parsedAsPrimitive(Enum<EnumWithValueField> item) {
         String json = TestUtil.toJson(item, new WriteOptionsBuilder().build());
-        EnumWithValueField actual = TestUtil.toObjects(json, null);
+        EnumWithValueField actual = TestUtil.toObjects(json, EnumWithValueField.class);
 
         assertThat(actual).isEqualTo(item);
     }


### PR DESCRIPTION
## Summary
- ensure enums written as primitive strings are read using the proper class
- document EnumTests fix in changelog

## Testing
- `mvn -q -Dtest=EnumTests#testEnum_thatHasValueField_parsedAsPrimitive test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68539f841414832aa1f15f23d3069995