### PR TITLE
Fix enum alias serialization with coercion

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 * Tests avoid `ByteArrayOutputStream.toString(Charset)` for JDK 8 compatibility
 * Documentation updated with guidance for parsing JSON that references unknown classes
 * RecordFactory now uses java-util `ReflectionUtils`
+* Fixed enum alias with coercion when writing enums as strings
 * Added RecordReader test
 * Added tests for WriteOptionsBuilder features
 * Fixed NamedMethodFilter test by making Example class public

--- a/src/main/java/com/cedarsoftware/io/JsonWriter.java
+++ b/src/main/java/com/cedarsoftware/io/JsonWriter.java
@@ -369,7 +369,10 @@ public class JsonWriter implements WriterContext, Closeable, Flushable
                 } else if (!writeOptions.isAlwaysShowingType()) {
                     JsonClassWriter writer = writeOptions.getCustomWriter(obj.getClass());
                     if (writer instanceof Writers.EnumsAsStringWriter) {
-                        showType = false;
+                        String alias = writeOptions.getTypeNameAlias(obj.getClass().getName());
+                        if (alias.equals(obj.getClass().getName())) {
+                            showType = false;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- ensure enum aliases preserve `@type` when writing
- document enum alias/coercion fix in changelog

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6853a0d42c54832a81b622882178b5a6