### PR TITLE
Fix enum aliasing test

### DIFF
--- a/src/test/java/com/cedarsoftware/io/EnumAliasCoercionTest.java
+++ b/src/test/java/com/cedarsoftware/io/EnumAliasCoercionTest.java
@@ -29,6 +29,7 @@ class EnumAliasCoercionTest {
         // Add alias
         WriteOptions writeOptions = new WriteOptionsBuilder()
                 .aliasTypeName(OldEnum.class.getName(), "OldEnum")
+                .writeEnumAsJsonObject(false)
                 .build();
 
         // Write using alias


### PR DESCRIPTION
## Summary
- ensure enum objects are written when aliasing

## Testing
- `mvn -q -Dtest=EnumAliasCoercionTest test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853a0f3f720832abca838cf54b5f342