### PR TITLE
Fix EnumBasicCreationTest for new default enum output

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -40,6 +40,7 @@
 * Added tests for ObjectResolver.safeToString
 * Added tests for ReadOptionsBuilder configuration methods
 * Corrected Example visibility in WriteOptionsBuilder tests
+* Updated EnumBasicCreationTest to expect string output for top-level enums
 * Added APIs to remove permanent method filters and accessor factories
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`

--- a/src/test/java/com/cedarsoftware/io/EnumBasicCreationTest.java
+++ b/src/test/java/com/cedarsoftware/io/EnumBasicCreationTest.java
@@ -33,11 +33,11 @@ class EnumBasicCreationTest {
     void testEnum_currentFormat() {
         SimpleTestEnum source = SimpleTestEnum.BETA;
         String json = TestUtil.toJson(source);
-        SimpleTestEnum target = TestUtil.toObjects(json, null);
+        SimpleTestEnum target = TestUtil.toObjects(json, SimpleTestEnum.class);
 
         assertThat(target).isEqualTo(source);
-        assertThat(json).contains(TYPE);
-        assertThat(json).contains("\"name\":\"BETA\"");
+        assertThat(json).doesNotContain(TYPE);
+        assertThat(json).contains("BETA");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- align EnumBasicCreationTest with default enum serialization
- note enum test update in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853a13188c0832a82aae6e74648bd8c