### PR TITLE
Fix enum alias coercion test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 * Corrected assertion for `retainAll` result in `SealableNavigableSetAdditionalTest`
 * Tests avoid `ByteArrayOutputStream.toString(Charset)` for JDK 8 compatibility
 * Documentation updated with guidance for parsing JSON that references unknown classes
+* Enum alias/coercion tests now force type info to be written so enums deserialize correctly
 * RecordFactory now uses java-util `ReflectionUtils`
 * Fixed `EnumTests` to deserialize enums written as primitive strings by providing the root class
 * Added RecordReader test

--- a/src/test/java/com/cedarsoftware/io/EnumAliasCoercionTest.java
+++ b/src/test/java/com/cedarsoftware/io/EnumAliasCoercionTest.java
@@ -29,6 +29,7 @@ class EnumAliasCoercionTest {
         // Add alias
         WriteOptions writeOptions = new WriteOptionsBuilder()
                 .aliasTypeName(OldEnum.class.getName(), "OldEnum")
+                .showTypeInfoAlways()
                 .build();
 
         // Write using alias
@@ -78,6 +79,7 @@ class EnumAliasCoercionTest {
         // Create write options with alias
         WriteOptions writeOptions = new WriteOptionsBuilder()
                 .aliasTypeName(OldEnum.class.getName(), "OldEnum")
+                .showTypeInfoAlways()
                 .build();
 
         // Write with alias


### PR DESCRIPTION
## Summary
- ensure enum alias tests always write `@type`
- document enum alias test update in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853a34aa994832a8a97c7c0afeebdd3