### PR TITLE
Fix enum string conversion

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 * Documentation updated with guidance for parsing JSON that references unknown classes
 * Enum alias/coercion tests now force type info to be written so enums deserialize correctly
 * RecordFactory now uses java-util `ReflectionUtils`
+* Added String-to-enum fallback conversion for root objects
 * Fixed NamedMethodFilter test by making Example class public
 * Added NamedMethodFilter tests and null-safe handling
 * Fixed `SealableNavigableSet.tailSet(E)` to include the starting element

--- a/src/main/java/com/cedarsoftware/io/JsonReader.java
+++ b/src/main/java/com/cedarsoftware/io/JsonReader.java
@@ -367,7 +367,11 @@ public class JsonReader implements Closeable
             return returnValue;
         }
 
-        // If the rootType is a primitive type, try to convert to its wrapper class
+        // Allow simple String to Enum conversion when needed
+        if (rootClass.isEnum() && returnValue instanceof String) {
+            return Enum.valueOf((Class<Enum>) rootClass, (String) returnValue);
+        }
+
         try {
             return localConverter.convert(returnValue, rootClass);
         } catch (Exception e) {


### PR DESCRIPTION
## Summary
- handle Enum values written as bare strings when a specific type is requested
- document string-to-enum fallback in changelog

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6853a5c8367c832a99f78dcee8e7a26c