### PR TITLE
Fix enum field deserialization

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 * Documentation updated with guidance for parsing JSON that references unknown classes
 * Enum alias/coercion tests now force type info to be written so enums deserialize correctly
 * RecordFactory now uses java-util `ReflectionUtils`
+* Root-level enums with fields now include type info for reliable deserialization
 * Added String-to-enum fallback conversion for root objects
 * Fixed NamedMethodFilter test by making Example class public
 * Added NamedMethodFilter tests and null-safe handling

--- a/src/main/java/com/cedarsoftware/io/JsonWriter.java
+++ b/src/main/java/com/cedarsoftware/io/JsonWriter.java
@@ -369,9 +369,12 @@ public class JsonWriter implements WriterContext, Closeable, Flushable
                 } else if (!writeOptions.isAlwaysShowingType()) {
                     JsonClassWriter writer = writeOptions.getCustomWriter(obj.getClass());
                     if (writer instanceof Writers.EnumsAsStringWriter) {
-                        String alias = writeOptions.getTypeNameAlias(obj.getClass().getName());
-                        if (alias.equals(obj.getClass().getName())) {
-                            showType = false;
+                        int fieldCount = writeOptions.getAccessorsForClass(obj.getClass()).size();
+                        if (fieldCount <= 2) {
+                            String alias = writeOptions.getTypeNameAlias(obj.getClass().getName());
+                            if (alias.equals(obj.getClass().getName())) {
+                                showType = false;
+                            }
                         }
                     }
                 }

--- a/user-guide-writeOptions.md
+++ b/user-guide-writeOptions.md
@@ -252,7 +252,7 @@ Here's how you configure these options in `json-io`:
 
 >#### `WriteOptionsBuilder` writeEnumsAsString()
 >- [ ] Sets the option to write enums as a `String.` This is the default option.  If you have called `writeEnumAsJsonObject(true or false),` call `writeEnumsAsString()`to return to enum output as `String.`
-- [ ] Top-level enums written as strings omit `@type` metadata.
+- [ ] Top-level enums written as strings omit `@type` metadata unless the enum defines additional fields, in which case the type is included so it can round-trip correctly.
 >#### `WriteOptionsBuilder` writeEnumAsJsonObject(`boolean writePublicFieldsOnly`)
 >- [ ] Sets the option to write all the member fields of an enum, using JSON { } format for the enum, to allow for multiple fields. Setting this option to `true` or `false` (include/exclude private fields), turns off the writeEnumsAsString() option. This option is off by default - enums are written as `String` by default.
 >#### `WriteOptionsBuilder` writeEnumSetOldWay(`boolean writeEnumSetOldWay`)


### PR DESCRIPTION
## Summary
- include enum class info when enums contain extra fields
- note enum type info behavior in documentation
- document change in changelog

## Testing
- `mvn -q test` *(failed: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853a70a0168832a82316b9e31c2de61