### PR TITLE
Add tests for Resolver.valueToTarget

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,7 @@
 * Fixed `SealableNavigableSet.tailSet(E)` to include the starting element
 * Expanded `SingletonList` tests for branch coverage
 * Added tests for Resolver.setArrayElement error paths and primitives
+* Added tests for `Resolver.valueToTarget` array conversions
 * Fixed VarHandle reflection to allow private-constructor injector
 * RecordFactory now checks the Java version before using records
 * Fixed VarHandle injection using a MethodHandle

--- a/src/test/java/com/cedarsoftware/io/ResolverValueToTargetTest.java
+++ b/src/test/java/com/cedarsoftware/io/ResolverValueToTargetTest.java
@@ -1,0 +1,79 @@
+package com.cedarsoftware.io;
+
+import com.cedarsoftware.io.JsonReader.DefaultReferenceTracker;
+import com.cedarsoftware.util.convert.Converter;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ResolverValueToTargetTest {
+
+    private static class TestResolver extends Resolver {
+        TestResolver(ReadOptions options) {
+            super(options, new DefaultReferenceTracker(), new Converter(options.getConverterOptions()));
+        }
+
+        boolean callValueToTarget(JsonObject obj) {
+            return valueToTarget(obj);
+        }
+
+        @Override
+        public void traverseFields(JsonObject jsonObj) {
+        }
+
+        @Override
+        protected Object readWithFactoryIfExists(Object o, Type compType) {
+            return null;
+        }
+
+        @Override
+        protected void traverseCollection(JsonObject jsonObj) {
+        }
+
+        @Override
+        protected void traverseArray(JsonObject jsonObj) {
+        }
+
+        @Override
+        protected Object resolveArray(Type suggestedType, List<Object> list) {
+            return null;
+        }
+    }
+
+    private final TestResolver resolver = new TestResolver(new ReadOptionsBuilder().build());
+
+    @Test
+    void nullTypeReturnsFalse() {
+        JsonObject obj = new JsonObject();
+        assertThat(resolver.callValueToTarget(obj)).isFalse();
+    }
+
+    @Test
+    void convertsPrimitiveArray() {
+        JsonObject nested = new JsonObject();
+        nested.setType(int.class);
+        nested.setValue("3");
+
+        JsonObject arrayObj = new JsonObject();
+        arrayObj.setType(int[].class);
+        arrayObj.setItems(new Object[]{1, "2", nested});
+
+        assertThat(resolver.callValueToTarget(arrayObj)).isTrue();
+        assertThat(arrayObj.getTarget()).isInstanceOf(int[].class);
+        assertThat((int[]) arrayObj.getTarget()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void conversionFailureWrapsException() {
+        JsonObject arrayObj = new JsonObject();
+        arrayObj.setType(int[].class);
+        arrayObj.setItems(new Object[]{"bad"});
+
+        assertThatThrownBy(() -> resolver.callValueToTarget(arrayObj))
+                .isInstanceOf(JsonIoException.class);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests covering Resolver.valueToTarget array logic
- document new tests in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853f4f439d0832a91cb85b721f1a36d