### PR TITLE
Fix primitive array handling in Resolver

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
 * Expanded `SingletonList` tests for branch coverage
 * Added tests for Resolver.setArrayElement error paths and primitives
 * Added tests for `Resolver.valueToTarget` array conversions
+* Fixed primitive array conversion handling in `Resolver.valueToTarget`
 * Fixed VarHandle reflection to allow private-constructor injector
 * RecordFactory now checks the Java version before using records
 * Fixed VarHandle injection using a MethodHandle

--- a/src/main/java/com/cedarsoftware/io/Resolver.java
+++ b/src/main/java/com/cedarsoftware/io/Resolver.java
@@ -673,7 +673,9 @@ public abstract class Resolver {
 
         Class<?> javaType = jsonObject.getRawType();
         // For arrays, attempt simple type conversion.
-        if (javaType.isArray() && converter.isSimpleTypeConversionSupported(javaType.getComponentType(), javaType)) {
+        if (javaType.isArray() &&
+                converter.isSimpleTypeConversionSupported(javaType.getComponentType(),
+                        javaType.getComponentType())) {
             Object[] jsonItems = jsonObject.getItems();
             Class<?> componentType = javaType.getComponentType();
             if (jsonItems == null) {    // empty array


### PR DESCRIPTION
## Summary
- correct `Resolver.valueToTarget` check for primitive arrays
- document primitive array fix in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853f7473e80832a8be28e031c4725be