### PR TITLE
Add tests for Pattern and Currency

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,7 @@
 * Added unit test for Unicode surrogate pair escapes
 * Added APIs to remove permanent method filters and accessor factories
 * Fixed enum round-trip test to specify target class
+* Added tests covering Pattern and Currency serialization
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/CurrencyTest.java
+++ b/src/test/java/com/cedarsoftware/io/CurrencyTest.java
@@ -1,0 +1,65 @@
+package com.cedarsoftware.io;
+
+import java.util.Currency;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static com.cedarsoftware.util.MapUtilities.mapOf;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class CurrencyTest {
+
+    @Test
+    void testCurrencyStandalone() {
+        Currency expected = Currency.getInstance("USD");
+        String json = TestUtil.toJson(expected);
+        Currency actual = TestUtil.toObjects(json, null);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testCurrencyArray() {
+        Currency currency = Currency.getInstance("EUR");
+        Currency[] array = new Currency[]{ currency };
+        String json = TestUtil.toJson(array);
+        Currency[] actual = TestUtil.toObjects(json, null);
+        assertEquals(1, actual.length);
+        assertEquals(currency, actual[0]);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testCurrencyAsMapValue() {
+        Currency currency = Currency.getInstance("GBP");
+        Map<String, Currency> map = mapOf("c", currency);
+        String json = TestUtil.toJson(map);
+        Map<String, Currency> actual = TestUtil.toObjects(json, null);
+        assertThat(actual).hasSize(1);
+        assertEquals(currency, actual.get("c"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testCurrencyAsMapKey() {
+        Currency currency = Currency.getInstance("JPY");
+        Map<Currency, String> map = mapOf(currency, "yen");
+        String json = TestUtil.toJson(map);
+        Map<Currency, String> actual = TestUtil.toObjects(json, null);
+        assertThat(actual).hasSize(1);
+        Currency key = actual.keySet().iterator().next();
+        assertEquals(currency, key);
+    }
+
+    @Test
+    void testCurrencyReference() {
+        Currency currency = Currency.getInstance("CHF");
+        Object[] array = new Object[]{ currency, currency };
+        String json = TestUtil.toJson(array);
+        Object[] actual = TestUtil.toObjects(json, null);
+        assertSame(actual[0], actual[1]);
+        assertEquals(currency, actual[0]);
+    }
+}

--- a/src/test/java/com/cedarsoftware/io/PatternTest.java
+++ b/src/test/java/com/cedarsoftware/io/PatternTest.java
@@ -1,0 +1,68 @@
+package com.cedarsoftware.io;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import static com.cedarsoftware.util.MapUtilities.mapOf;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class PatternTest {
+
+    @Test
+    void testPatternStandalone() {
+        Pattern expected = Pattern.compile("ab.*c");
+        String json = TestUtil.toJson(expected);
+        Pattern actual = TestUtil.toObjects(json, null);
+        assertEquals(expected.pattern(), actual.pattern());
+        assertEquals(expected.flags(), actual.flags());
+    }
+
+    @Test
+    void testPatternArray() {
+        Pattern pattern = Pattern.compile("[A-Z]+\\d?");
+        Pattern[] array = new Pattern[]{ pattern };
+        String json = TestUtil.toJson(array);
+        Pattern[] actual = TestUtil.toObjects(json, null);
+        assertEquals(1, actual.length);
+        assertEquals(pattern.pattern(), actual[0].pattern());
+        assertEquals(pattern.flags(), actual[0].flags());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testPatternAsMapValue() {
+        Pattern pattern = Pattern.compile("foo.*");
+        Map<String, Pattern> map = mapOf("p", pattern);
+        String json = TestUtil.toJson(map);
+        Map<String, Pattern> actual = TestUtil.toObjects(json, null);
+        assertThat(actual).hasSize(1);
+        assertEquals(pattern.pattern(), actual.get("p").pattern());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testPatternAsMapKey() {
+        Pattern pattern = Pattern.compile("foo\\d+");
+        Map<Pattern, String> map = mapOf(pattern, "bar");
+        String json = TestUtil.toJson(map);
+        Map<Pattern, String> actual = TestUtil.toObjects(json, null);
+        assertThat(actual).hasSize(1);
+        Pattern key = actual.keySet().iterator().next();
+        assertEquals(pattern.pattern(), key.pattern());
+    }
+
+    @Test
+    void testPatternReference() {
+        Pattern pattern = Pattern.compile("h.*");
+        Object[] array = new Object[]{ pattern, pattern };
+        String json = TestUtil.toJson(array);
+        Object[] actual = TestUtil.toObjects(json, null);
+        assertSame(actual[0], actual[1]);
+        Pattern result = (Pattern) actual[0];
+        assertEquals(pattern.pattern(), result.pattern());
+    }
+}


### PR DESCRIPTION
## Summary
- verify json-io handles java.util.regex.Pattern
- verify json-io handles java.util.Currency
- document new tests

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853fb6b95f0832aa45f1dbf6f165b20