### PR TITLE
Add unit test for permanent accessor removal

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,7 @@
 * SealableSet(Collection) now copies the supplied collection instead of wrapping it
 * Added unit test for Unicode surrogate pair escapes
 * Added APIs to remove permanent method filters and accessor factories
+* Added unit test for removePermanentAccessorFactory
 * Fixed enum round-trip test to specify target class
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`

--- a/src/test/java/com/cedarsoftware/io/WriteOptionsBuilderTest.java
+++ b/src/test/java/com/cedarsoftware/io/WriteOptionsBuilderTest.java
@@ -174,5 +174,22 @@ public class WriteOptionsBuilderTest {
         opts2.getAccessorsForClass(Example.class);
         assertFalse(factory2.called);
     }
+
+    @Test
+    void testRemovePermanentAccessorFactory() {
+        TestAccessorFactory factory = new TestAccessorFactory();
+        WriteOptionsBuilder.addPermanentAccessorFactory("temp", factory);
+
+        WriteOptions opts = new WriteOptionsBuilder().build();
+        opts.getAccessorsForClass(Example.class);
+        assertTrue(factory.called);
+
+        factory.called = false;
+        WriteOptionsBuilder.removePermanentAccessorFactory("temp");
+
+        WriteOptions opts2 = new WriteOptionsBuilder().build();
+        opts2.getAccessorsForClass(Example.class);
+        assertFalse(factory.called);
+    }
 }
 


### PR DESCRIPTION
## Summary
- test removing permanent accessor factories
- document change in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853fbac9108832a9817dc6490bc5b9e