### PR TITLE
Add DateAsLongWriter test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@
 * Added unit test for removePermanentAccessorFactory
 * Fixed enum round-trip test to specify target class
 * Added tests covering Pattern and Currency serialization
+* Added unit test for Writers.DateAsLongWriter
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/DateAsLongWriterTest.java
+++ b/src/test/java/com/cedarsoftware/io/DateAsLongWriterTest.java
@@ -1,0 +1,35 @@
+package com.cedarsoftware.io;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DateAsLongWriterTest
+{
+    private static class DateHolder {
+        private Date util;
+        private java.sql.Date sql;
+    }
+
+    @Test
+    void testDateAsLongWriter()
+    {
+        DateHolder holder = new DateHolder();
+        holder.util = new Date(1700000000000L);
+        holder.sql = java.sql.Date.valueOf("2024-02-02");
+
+        WriteOptions options = new WriteOptionsBuilder().longDateFormat().build();
+        String json = TestUtil.toJson(holder, options);
+
+        assertTrue(json.contains("\"util\":" + holder.util.getTime()));
+        assertTrue(json.contains("\"sql\":\"" + holder.sql.toLocalDate().toString() + "\""));
+
+        DateHolder result = TestUtil.toObjects(json, DateHolder.class);
+        assertEquals(holder.util.getTime(), result.util.getTime());
+        assertEquals(holder.sql, result.sql);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit test covering Writers.DateAsLongWriter
- document the new test in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853ff2c1640832a8ed131b195dbd6bd