### PR TITLE
Fix failing JsonReader test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,7 @@
 * Added unit test for Unicode surrogate pair escapes
 * Added APIs to remove permanent method filters and accessor factories
 * Added unit test for removePermanentAccessorFactory
+* Fixed failing test for non-simple root type handling
 * Fixed enum round-trip test to specify target class
 * Added tests covering Pattern and Currency serialization
 #### 4.54.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/JsonReaderHandleObjectRootTest.java
+++ b/src/test/java/com/cedarsoftware/io/JsonReaderHandleObjectRootTest.java
@@ -92,7 +92,7 @@ class JsonReaderHandleObjectRootTest {
         IdentityReader reader = new IdentityReader(opts);
         JsonObject obj = new JsonObject();
         obj.setTarget("hello");
-        obj.setType(Object.class);
+        obj.setType(Thread.class); // use a non-simple type
         Object result = reader.invokeHandle(null, obj);
         assertEquals("hello", result);
     }


### PR DESCRIPTION
## Summary
- fix `simpleGraphReturnedWhenTypeNotSimple` test to use a non-convertible type
- update changelog

## Testing
- `mvn -q test` *(failed: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685404767f80832aa3ddc08b3851be01