### PR TITLE
Fix broken root type test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@
 * Added unit test for removePermanentAccessorFactory
 * Fixed enum round-trip test to specify target class
 * Added tests covering Pattern and Currency serialization
+* Updated JsonReaderHandleObjectRootTest to expect JsonIoException on return type mismatch
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/JsonReaderHandleObjectRootTest.java
+++ b/src/test/java/com/cedarsoftware/io/JsonReaderHandleObjectRootTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.cedarsoftware.io.JsonIoException;
+
 class JsonReaderHandleObjectRootTest {
 
     static class NullReader extends JsonReader {
@@ -73,7 +75,7 @@ class JsonReaderHandleObjectRootTest {
     @Test
     void incompatibleRootTypeThrows() {
         String json = "{\"@type\":\"java.util.concurrent.atomic.AtomicInteger\",\"value\":5}";
-        assertThrows(ClassCastException.class, () -> TestUtil.toObjects(json, List.class));
+        assertThrows(JsonIoException.class, () -> TestUtil.toObjects(json, List.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- update JsonReaderHandleObjectRootTest to expect JsonIoException
- document the test update in changelog

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68540532bb98832a8dd082c75d380343