### PR TITLE
Fix EnumSet traversal for missing names

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@
 * Fixed `SealableNavigableSet.tailSet(E)` to include the starting element
 * Expanded `SingletonList` tests for branch coverage
 * Fixed primitive array conversion handling in `Resolver.valueToTarget`
+* Fixed EnumSet traversal when enum element lacks a name
 * Fixed VarHandle reflection to allow private-constructor injector
 * Fixed VarHandle injection using a MethodHandle
 * Fixed VarHandle injection invocation for reflection-based Injector

--- a/src/main/java/com/cedarsoftware/io/MapResolver.java
+++ b/src/main/java/com/cedarsoftware/io/MapResolver.java
@@ -279,6 +279,16 @@ public class MapResolver extends Resolver {
                             }
                         }
                     } else {
+                        if (col instanceof EnumSet) {
+                            Class<?> rawType = jObj.getRawType();
+                            boolean noEnumName = !jObj.containsKey("name") && !jObj.containsKey("Enum.name") && !jObj.hasValue();
+                            if (rawType != null && rawType.isEnum() && noEnumName) {
+                                jObj.setFinished();
+                                idx++;
+                                continue;
+                            }
+                        }
+
                         jObj.setType(Object.class);
                         createInstance(jObj);
                         boolean isNonRefClass = getReadOptions().isNonReferenceableClass(jObj.getRawType());


### PR DESCRIPTION
## Summary
- handle missing enum name when traversing EnumSet elements
- document fix in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68540572cac0832a917acc61eb627d50