### PR TITLE
Add missing converter options test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * Fixed deserialization of Java records
 * Tests now create record classes via reflection for JDK 8 compile compatibility.
 * Replaced `System.out.println` debug output with Java logging via `LoggingConfig`
+* Added unit test for `DefaultConverterOptions.getCustomOption`
 * SealableNavigableMap now wraps returned entries to enforce immutability
 * Preserve comparator when constructing `SealableNavigableSet` from a `SortedSet`
 * Documentation expanded for CompactMap usage and builder() caveats

--- a/src/test/java/com/cedarsoftware/io/ReadOptionsBuilderTest.java
+++ b/src/test/java/com/cedarsoftware/io/ReadOptionsBuilderTest.java
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.lang.reflect.Field;
 
 import org.junit.jupiter.api.Test;
 
@@ -94,5 +95,21 @@ class ReadOptionsBuilderTest {
         assertThat(options.getConverterOptions().falseChar()).isEqualTo('N');
         assertThat(options.getCustomOption("foo")).isEqualTo("bar");
         assertTrue(options.isNonReferenceableClass(NonRefClass.class));
+    }
+
+    @Test
+    void testDefaultConverterOptionsGetCustomOption() throws Exception {
+        ReadOptionsBuilder.DefaultConverterOptions opts =
+                new ReadOptionsBuilder.DefaultConverterOptions();
+
+        Field field = ReadOptionsBuilder.DefaultConverterOptions.class
+                .getDeclaredField("customOptions");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = (Map<String, Object>) field.get(opts);
+        map.put("bar", 123);
+
+        assertThat(opts.getCustomOption("bar")).isEqualTo(123);
+        assertNull(opts.getCustomOption("missing"));
     }
 }


### PR DESCRIPTION
## Summary
- add test for DefaultConverterOptions custom option lookup
- document change in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68541d323908832aa5f1b67d239b3e60