### PR TITLE
Add tests for ReadOptions defaults

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -39,6 +39,7 @@
 * Fixed enum round-trip test to specify target class
 * Added tests covering Pattern and Currency serialization
 * Updated JsonReaderHandleObjectRootTest to expect JsonIoException on return type mismatch
+* Added unit tests for ReadOptionsBuilder DefaultReadOptions `getLruSize()` and `isClassCoerced()`
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/ReadOptionsBuilderTest.java
+++ b/src/test/java/com/cedarsoftware/io/ReadOptionsBuilderTest.java
@@ -95,4 +95,29 @@ class ReadOptionsBuilderTest {
         assertThat(options.getCustomOption("foo")).isEqualTo("bar");
         assertTrue(options.isNonReferenceableClass(NonRefClass.class));
     }
+
+    @Test
+    void testLruSize_defaultAndCustom() {
+        ReadOptions defaultOptions = new ReadOptionsBuilder().build();
+        assertThat(defaultOptions.getLruSize()).isEqualTo(1000);
+
+        ReadOptions customOptions = new ReadOptionsBuilder()
+                .lruSize(42)
+                .build();
+        assertThat(customOptions.getLruSize()).isEqualTo(42);
+    }
+
+    static class SourceClass {}
+    static class DestinationClass {}
+
+    @Test
+    void testIsClassCoerced() {
+        ReadOptions options = new ReadOptionsBuilder()
+                .coerceClass(SourceClass.class.getName(), DestinationClass.class)
+                .build();
+
+        assertFalse(new ReadOptionsBuilder().build().isClassCoerced(SourceClass.class));
+        assertTrue(options.isClassCoerced(SourceClass.class));
+        assertThat(options.getCoercedClass(SourceClass.class)).isSameAs(DestinationClass.class);
+    }
 }


### PR DESCRIPTION
## Summary
- add tests for `DefaultReadOptions.getLruSize` and `isClassCoerced`
- document the new tests in `changelog.md`

## Testing
- `mvn -q test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68541d8cbbf8832ab79f0ac4acaf99b7