### PR TITLE
Add JsonObject null input tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -39,6 +39,7 @@
 * Fixed enum round-trip test to specify target class
 * Added tests covering Pattern and Currency serialization
 * Updated JsonReaderHandleObjectRootTest to expect JsonIoException on return type mismatch
+* Added tests verifying JsonObject#setItems and setKeys throw when passed null
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/JsonObjectMethodsTest.java
+++ b/src/test/java/com/cedarsoftware/io/JsonObjectMethodsTest.java
@@ -173,5 +173,19 @@ class JsonObjectMethodsTest {
         assertFalse((boolean) m.invoke(null, new Object[]{"a"}, new Object[]{"b"}));
         assertTrue((boolean) m.invoke(null, new Object[]{"a", null}, new Object[]{"a", null}));
     }
+
+    @Test
+    void testSetItemsNullThrows() {
+        JsonObject obj = new JsonObject();
+        JsonIoException ex = assertThrows(JsonIoException.class, () -> obj.setItems(null));
+        assertTrue(ex.getMessage().toLowerCase().contains("cannot be null"));
+    }
+
+    @Test
+    void testSetKeysNullThrows() {
+        JsonObject obj = new JsonObject();
+        JsonIoException ex = assertThrows(JsonIoException.class, () -> obj.setKeys(null));
+        assertTrue(ex.getMessage().toLowerCase().contains("cannot be null"));
+    }
 }
 


### PR DESCRIPTION
## Summary
- add missing null input tests for `JsonObject.setItems` and `setKeys`
- document new tests in `changelog.md`

## Testing
- `mvn -q test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68541e5c54a4832abef056725f014145