### PR TITLE
Add Javadoc for ByteArrayWriter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ### Revision History
 #### 4.55.0 (unreleased) Updated to use java-util 3.3.3
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.2` to `3.3.3.`
+* Added class-level Javadoc for `ByteArrayWriter` describing Base64 encoding
 * Fixed deserialization of Java records
 * Tests now create record classes via reflection for JDK 8 compile compatibility.
 * Replaced `System.out.println` debug output with Java logging via `LoggingConfig`

--- a/src/main/java/com/cedarsoftware/io/writers/ByteArrayWriter.java
+++ b/src/main/java/com/cedarsoftware/io/writers/ByteArrayWriter.java
@@ -9,6 +9,26 @@ import com.cedarsoftware.io.WriterContext;
 import static com.cedarsoftware.io.JsonWriter.JsonClassWriter;
 import static com.cedarsoftware.io.JsonWriter.writeBasicString;
 
+/**
+ * Writer that encodes a byte array to Base64 and implements {@link JsonClassWriter}.
+ *
+ * @author John DeRegnaucourt (jdereg@gmail.com)
+ *         <br>
+ *         Copyright (c) Cedar Software LLC
+ *         <br><br>
+ *         Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *         <br><br>
+ *         <a href="http://www.apache.org/licenses/LICENSE-2.0">License</a>
+ *         <br><br>
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ */
+
 public class ByteArrayWriter implements JsonClassWriter {
 
     @Override


### PR DESCRIPTION
## Summary
- document ByteArrayWriter with class-level Javadoc
- note the new documentation in the changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68541ebb9880832a84db6eca5eb72cfb