### PR TITLE
Add Javadoc for ZoneIdWriter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@
 * Fixed failing test for non-simple root type handling
 * Fixed enum round-trip test to specify target class
 * Added tests covering Pattern and Currency serialization
+* Added Javadoc for ZoneIdWriter describing its behavior
 * Updated JsonReaderHandleObjectRootTest to expect JsonIoException on return type mismatch
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`

--- a/src/main/java/com/cedarsoftware/io/writers/ZoneIdWriter.java
+++ b/src/main/java/com/cedarsoftware/io/writers/ZoneIdWriter.java
@@ -4,6 +4,25 @@ import java.time.ZoneId;
 
 import com.cedarsoftware.io.Writers;
 
+/**
+ * Writer that serializes {@link ZoneId} values as their string identifiers.
+ *
+ * @author John DeRegnaucourt (jdereg@gmail.com)
+ *         <br>
+ *         Copyright (c) Cedar Software LLC
+ *         <br><br>
+ *         Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *         <br><br>
+ *         <a href="http://www.apache.org/licenses/LICENSE-2.0">License</a>
+ *         <br><br>
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ */
 public class ZoneIdWriter extends Writers.PrimitiveUtf8StringWriter {
 
     @Override


### PR DESCRIPTION
## Summary
- document ZoneIdWriter with usage and license details
- note the documentation update in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68541ebfd2c8832aa6cb907a49040f89