### PR TITLE
Add JsonObject map-view tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,7 @@
 * Fixed primitive array conversion handling in `Resolver.valueToTarget`
 * Fixed EnumSet traversal when enum element lacks a name
 * Fixed VarHandle reflection to allow private-constructor injector
+* Added unit tests for JsonObject map-view methods
 * Fixed VarHandle injection using a MethodHandle
 * Fixed VarHandle injection invocation for reflection-based Injector
 * Fixed Injector method-based creation to correctly locate void setters

--- a/src/test/java/com/cedarsoftware/io/JsonObjectMethodsTest.java
+++ b/src/test/java/com/cedarsoftware/io/JsonObjectMethodsTest.java
@@ -6,6 +6,10 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.AbstractMap;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -186,6 +190,83 @@ class JsonObjectMethodsTest {
         JsonObject obj = new JsonObject();
         JsonIoException ex = assertThrows(JsonIoException.class, () -> obj.setKeys(null));
         assertTrue(ex.getMessage().toLowerCase().contains("cannot be null"));
+    }
+
+    @Test
+    void testContainsKeyUsesArraysAndDelegates() {
+        JsonObject obj = new JsonObject();
+        obj.setKeys(new Object[]{"a", "b"});
+        assertTrue(obj.containsKey("a"));
+        assertFalse(obj.containsKey("c"));
+
+        JsonObject delegated = new JsonObject();
+        delegated.put("x", 1);
+        assertTrue(delegated.containsKey("x"));
+        assertFalse(delegated.containsKey("y"));
+    }
+
+    @Test
+    void testContainsValueUsesArraysAndDelegates() {
+        JsonObject obj = new JsonObject();
+        obj.setItems(new Object[]{1, 2});
+        assertTrue(obj.containsValue(2));
+        assertFalse(obj.containsValue(3));
+
+        JsonObject delegated = new JsonObject();
+        delegated.put("k", 5);
+        assertTrue(delegated.containsValue(5));
+        assertFalse(delegated.containsValue(6));
+    }
+
+    @Test
+    void testGetKeyFromArraysAndDelegates() {
+        JsonObject obj = new JsonObject();
+        obj.setKeys(new Object[]{"a"});
+        obj.setItems(new Object[]{10});
+        assertEquals(10, obj.get("a"));
+        assertNull(obj.get("b"));
+
+        JsonObject delegated = new JsonObject();
+        delegated.put("x", 42);
+        assertEquals(42, delegated.get("x"));
+    }
+
+    @Test
+    void testKeySetAndValues() {
+        JsonObject obj = new JsonObject();
+        Object[] keys = {"k1", "k2"};
+        Object[] items = {1, 2};
+        obj.setKeys(keys);
+        obj.setItems(items);
+        assertEquals(new LinkedHashSet<>(Arrays.asList(keys)), obj.keySet());
+        assertEquals(new LinkedHashSet<>(Arrays.asList(items)), new LinkedHashSet<>(obj.values()));
+
+        JsonObject delegated = new JsonObject();
+        delegated.put("x", 1);
+        assertTrue(delegated.keySet().contains("x"));
+        assertTrue(delegated.values().contains(1));
+    }
+
+    @Test
+    void testEntrySetFromArraysAndDelegate() {
+        JsonObject obj = new JsonObject();
+        obj.setKeys(new Object[]{"a"});
+        obj.setItems(new Object[]{1});
+        Set<Map.Entry<Object, Object>> entries = obj.entrySet();
+        Map.Entry<Object, Object> entry = entries.iterator().next();
+        assertEquals("a", entry.getKey());
+        assertEquals(1, entry.getValue());
+        assertEquals(1, entry.setValue(5));
+        assertEquals(5, entry.getValue());
+        assertEquals(5, obj.getItems()[0]);
+        assertTrue(entry.equals(new AbstractMap.SimpleEntry<>("a", 5)));
+
+        JsonObject delegated = new JsonObject();
+        delegated.put("k", 10);
+        Set<Map.Entry<Object, Object>> delegatedEntries = delegated.entrySet();
+        Map.Entry<Object, Object> delegatedEntry = delegatedEntries.iterator().next();
+        assertEquals("k", delegatedEntry.getKey());
+        assertEquals(10, delegatedEntry.getValue());
     }
 }
 


### PR DESCRIPTION
## Summary
- add unit tests for JsonObject map-view methods
- document the new tests in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68542468fa4c832abec66794fdb76f0e