### PR TITLE
Add regression test for timestamp map

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -43,6 +43,7 @@
 * Added tests covering Pattern and Currency serialization
 * Added Javadoc for ZoneIdWriter describing its behavior
 * Updated JsonReaderHandleObjectRootTest to expect JsonIoException on return type mismatch
+* Added regression test for ISO Timestamp Map conversion
 #### 4.54.0 Updated to use java-util 3.3.1
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.1` to `3.3.2.`
 #### 4.53.0 Updated to use java-util 3.3.1

--- a/src/test/java/com/cedarsoftware/io/MapTimestampConversionTest.java
+++ b/src/test/java/com/cedarsoftware/io/MapTimestampConversionTest.java
@@ -1,0 +1,19 @@
+package com.cedarsoftware.io;
+
+import java.sql.Timestamp;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Regression tests for converting Map representations to {@link Timestamp}.
+ */
+class MapTimestampConversionTest {
+    @Test
+    void testIsoStringTimestampFails() {
+        String json = "{\"@type\":\"java.sql.Timestamp\",\"timestamp\":\"2025-06-19T13:46:38.745Z\"}";
+        assertThrows(IllegalArgumentException.class, () -> TestUtil.toObjects(json, Timestamp.class));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add MapTimestampConversionTest to reproduce timestamp map handling
- document the new test in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68545f7d01f4832a820ae94176661da5