### PR TITLE
Update docs for -parameters support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Key Features:
 - Fully compatible with both JPMS and OSGi environments
 - Lightweight (`json-io.jar` is 258K, `java-util` is 471K)
 - Compatible with JDK 1.8 through JDK 24
+- Built with Java's `-parameters` flag for constructor argument name support
 - Extensive configuration options via `ReadOptionsBuilder` and `WriteOptionsBuilder`
 - Optionally parse JSON with unknown class references into a Map-of-Maps representation
 - Featured on [json.org](http://json.org)
@@ -58,12 +59,12 @@ ___
 >- [ ] **Bundling**: Both JPMS (Java Platform Module System) and OSGi (Open Service Gateway initiative)
 >- [ ] **Maintained**: Fully
 >- [ ] **Java Package**: com.cedarsoftware.io
->- [ ] **Java**: JDK1.8+ (Class file 52 format, includes module-info.class - multi-release JAR)
+>- [ ] **Java**: JDK1.8+ (Class file 52 format, includes module-info.class - multi-release JAR, built with `-parameters`)
 >- [ ] **API**
->  - Static methods on [JsonIo](https://www.javadoc.io/doc/com.cedarsoftware/json-io/4.55.0/com/cedarsoftware/io/JsonIo.html): [toJson()](https://www.javadoc.io/static/com.cedarsoftware/json-io/4.55.0/com/cedarsoftware/io/JsonIo.html#toJson(java.lang.Object,com.cedarsoftware.io.WriteOptions)), [toJava()](https://www.javadoc.io/doc/com.cedarsoftware/json-io/latest/com/cedarsoftware/io/JsonIo.html#toJava(com.cedarsoftware.io.JsonObject,com.cedarsoftware.io.ReadOptions)), [formatJson()](https://www.javadoc.io/static/com.cedarsoftware/json-io/4.55.0/com/cedarsoftware/io/JsonIo.html#formatJson(java.lang.String)), [deepCopy()](https://www.javadoc.io/static/com.cedarsoftware/json-io/4.55.0/com/cedarsoftware/io/JsonIo.html#deepCopy(java.lang.Object,com.cedarsoftware.io.ReadOptions,com.cedarsoftware.io.WriteOptions))
->  - Use [ReadOptionsBuilder](/user-guide-readOptions.md) and [WriteOptionsBuilder](/user-guide-writeOptions.md) to configure `JsonIo`
->  - Use [JsonReader.ClassFactory](https://www.javadoc.io/static/com.cedarsoftware/json-io/4.55.0/com/cedarsoftware/io/JsonReader.ClassFactory.html) for difficult classes (hard to instantiate & fill)
->  - Use [JsonWriter.JsonClassWriter](https://www.javadoc.io/static/com.cedarsoftware/json-io/4.55.0/com/cedarsoftware/io/JsonWriter.JsonClassWriter.html) to customize the output JSON for a particular class
+ >  - Static methods on [JsonIo](https://www.javadoc.io/doc/com.cedarsoftware/json-io/4.56.0/com/cedarsoftware/io/JsonIo.html): [toJson()](https://www.javadoc.io/static/com.cedarsoftware/json-io/4.56.0/com/cedarsoftware/io/JsonIo.html#toJson(java.lang.Object,com.cedarsoftware.io.WriteOptions)), [toJava()](https://www.javadoc.io/doc/com.cedarsoftware/json-io/latest/com/cedarsoftware/io/JsonIo.html#toJava(com.cedarsoftware.io.JsonObject,com.cedarsoftware.io.ReadOptions)), [formatJson()](https://www.javadoc.io/static/com.cedarsoftware/json-io/4.56.0/com/cedarsoftware/io/JsonIo.html#formatJson(java.lang.String)), [deepCopy()](https://www.javadoc.io/static/com.cedarsoftware/json-io/4.56.0/com/cedarsoftware/io/JsonIo.html#deepCopy(java.lang.Object,com.cedarsoftware.io.ReadOptions,com.cedarsoftware.io.WriteOptions))
+ >  - Use [ReadOptionsBuilder](/user-guide-readOptions.md) and [WriteOptionsBuilder](/user-guide-writeOptions.md) to configure `JsonIo`
+ >  - Use [JsonReader.ClassFactory](https://www.javadoc.io/static/com.cedarsoftware/json-io/4.56.0/com/cedarsoftware/io/JsonReader.ClassFactory.html) for difficult classes (hard to instantiate & fill)
+ >  - Use [JsonWriter.JsonClassWriter](https://www.javadoc.io/static/com.cedarsoftware/json-io/4.56.0/com/cedarsoftware/io/JsonWriter.JsonClassWriter.html) to customize the output JSON for a particular class
 >- [ ] Updates will be 4.56.0, 4.57.0, ...
 >### 4.14.x (supported)
 >- [ ] **Version**: [4.14.3](https://www.javadoc.io/doc/com.cedarsoftware/json-io/4.14.3/index.html)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 ### Revision History
 #### 4.56.0 (Unreleased)
+* Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.4.0` to `3.5.0.`
+* Jar now built with the `-parameters` flag enabling constructor parameter name matching
+* Improved object instantiation logic to use parameter names when available
+* Expanded `ThrowableFactory` to support parameter name aliases
+* Minor fixes and test updates
 #### 4.55.0 Updated to use java-util 3.4.0
 * Updated [java-util](https://github.com/jdereg/java-util/blob/master/changelog.md) from `3.3.2` to `3.4.0.`
 * Added class-level Javadoc for `ByteArrayWriter` describing Base64 encoding

--- a/user-guide.md
+++ b/user-guide.md
@@ -122,7 +122,7 @@ Map<String, List<Department<Employee>>> orgMap = JsonIo.toJava(json, readOptions
 Sometimes you will run into a class that does not want to serialize.  On the read-side, this can be a class that does
 not want to be instantiated easily.  A class that has private constructors, constructor with many difficult to supply
 arguments, etc. There are unlimited Java classes 'out-there' that `json-io` has never seen.  It can instantiate many classes, and
-resorts to a lot of "tricks" to make that happen.  However, if a particular class is not instantiating, add a
+resorts to a lot of "tricks" to make that happen.  As of version 4.56.0 the library itself is compiled with the `-parameters` flag, allowing `json-io` to match JSON fields directly to constructor parameter names when your classes are also compiled with this flag.  This greatly reduces the need for custom factories when classes have accessible constructors with named arguments.  However, if a particular class is not instantiating, add a
 `JsonReader.ClassFactory` (one that you write, which subclasses this interface) and associate it to the class you want to
 instantiate. See [examples](/src/test/java/com/cedarsoftware/io/CustomJsonSubObjectsTest.java) for how to do this.
 ```java


### PR DESCRIPTION
## Summary
- document new constructor parameter matching
- mention `-parameters` in README
- upgrade notes for java-util 3.5.0

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6858df86be30832a98eb71d43124b25f