### PR TITLE
Fix throwable factory message resolution

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * Improved object instantiation logic to use parameter names when available
 * Expanded `ThrowableFactory` to support parameter name aliases
 * Throwable instantiation now delegates to `Converter` for faster construction
+* Fixed exception message selection when using `ThrowableFactory`
 * Minor fixes and test updates
 * Reflection usage in `ReadOptionsBuilder` and `Injector` now leverages `ReflectionUtils` caching
 #### 4.55.0

--- a/src/main/java/com/cedarsoftware/io/factory/ThrowableFactory.java
+++ b/src/main/java/com/cedarsoftware/io/factory/ThrowableFactory.java
@@ -47,8 +47,12 @@ public class ThrowableFactory implements JsonReader.ClassFactory
         }
 
         // Alias for constructor parameter name
-        Object message = map.get(DETAIL_MESSAGE);
-        map.put("message", message == null ? "" : message);
+        Object message = map.remove(DETAIL_MESSAGE);
+        if (message == null) {
+            message = "";
+        }
+        map.put("message", message);
+        map.put("msg", message);
 
         // Instantiate using Converter to leverage MapConversions
         Throwable t = resolver.getConverter().convert(map, c);


### PR DESCRIPTION
## Summary
- ensure ThrowableFactory sets the message for all parameter names
- document fix in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b476d1fd0832aa6b3e50c22f3e4ec