### PR TITLE
Fix ThrowableFactory cause handling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 * Expanded `ThrowableFactory` to support parameter name aliases
 * Throwable instantiation now delegates to `Converter` for faster construction
 * Fixed exception message selection when using `ThrowableFactory`
+* Preserve null `cause` when constructing exceptions via `ThrowableFactory`
 * Minor fixes and test updates
 * Reflection usage in `ReadOptionsBuilder` and `Injector` now leverages `ReflectionUtils` caching
 #### 4.55.0

--- a/src/main/java/com/cedarsoftware/io/factory/ThrowableFactory.java
+++ b/src/main/java/com/cedarsoftware/io/factory/ThrowableFactory.java
@@ -42,9 +42,8 @@ public class ThrowableFactory implements JsonReader.ClassFactory
         Class<Throwable> causeType = jsonCause == null ? Throwable.class : (Class<Throwable>) jsonCause.getType();
         causeType = causeType == null ? Throwable.class : causeType;
         Throwable cause = resolver.toJavaObjects(jsonCause, causeType);
-        if (cause != null) {
-            map.put(CAUSE, cause);
-        }
+        // Keep 'cause' key present so MapConversions can match constructors
+        map.put(CAUSE, cause);
 
         // Alias for constructor parameter name
         Object message = map.remove(DETAIL_MESSAGE);


### PR DESCRIPTION
## Summary
- ensure `ThrowableFactory` preserves null cause when delegating to Converter
- update changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b49fcd428832a83ebff36ffbe5e21