### PR TITLE
Fix exception deserialization order

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Throwable instantiation now delegates to `Converter` for faster construction
 * Fixed exception message selection when using `ThrowableFactory`
 * Preserve null `cause` when constructing exceptions via `ThrowableFactory`
+* Ensure message field is written first to preserve constructor argument order
 * Minor fixes and test updates
 * Reflection usage in `ReadOptionsBuilder` and `Injector` now leverages `ReflectionUtils` caching
 #### 4.55.0


### PR DESCRIPTION
## Summary
- adjust `ThrowableFactory` to insert message first when building the constructor map
- update changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b4ba311cc832a89a9de96e3a738ec