### PR TITLE
Fix ThrowableFactory null cause

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Throwable instantiation now delegates to `Converter` for faster construction
 * Fixed exception message selection when using `ThrowableFactory`
 * Preserve null `cause` when constructing exceptions via `ThrowableFactory`
+* Treat empty `cause` objects as `null` during exception instantiation
 * Ensure message field is written first to preserve constructor argument order
 * Minor fixes and test updates
 * Reflection usage in `ReadOptionsBuilder` and `Injector` now leverages `ReflectionUtils` caching

--- a/src/main/java/com/cedarsoftware/io/factory/ThrowableFactory.java
+++ b/src/main/java/com/cedarsoftware/io/factory/ThrowableFactory.java
@@ -37,12 +37,18 @@ public class ThrowableFactory implements JsonReader.ClassFactory {
         // Pre-process the cause to ensure it's properly typed
         JsonObject jsonCause = (JsonObject) jObj.get(CAUSE);
         if (jsonCause != null) {
-            Class<Throwable> causeType = (Class<Throwable>) jsonCause.getType();
-            if (causeType != null) {
-                // Add type information to the cause map
-                Map<Object, Object> causeMap = new LinkedHashMap<>(jsonCause);
-                causeMap.put("@type", causeType.getName());
-                map.put(CAUSE, causeMap);
+            if (jsonCause.isEmpty()) {
+                // Writer sends an empty object when the cause is null. Remove
+                // the map entry so the constructor receives a true null.
+                map.put(CAUSE, null);
+            } else {
+                Class<Throwable> causeType = (Class<Throwable>) jsonCause.getType();
+                if (causeType != null) {
+                    // Add type information to the cause map
+                    Map<Object, Object> causeMap = new LinkedHashMap<>(jsonCause);
+                    causeMap.put("@type", causeType.getName());
+                    map.put(CAUSE, causeMap);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- handle empty cause objects in `ThrowableFactory`
- document exception fix in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b65ba4ed0832abe6b2376e3e0172f