### PR TITLE
fix: parse java version pre-release

### DIFF
--- a/src/test/java/com/cedarsoftware/io/reflect/InjectorTests.java
+++ b/src/test/java/com/cedarsoftware/io/reflect/InjectorTests.java
@@ -1,14 +1,15 @@
 package com.cedarsoftware.io.reflect;
 
-import com.cedarsoftware.io.JsonIoException;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import com.cedarsoftware.io.JsonIoException;
+
+import org.junit.jupiter.api.Test;
 
 class InjectorTests {
 
@@ -55,5 +56,35 @@ class InjectorTests {
         Throwable cause = ex.getCause();
         assertThat(cause).isInstanceOf(JsonIoException.class);
         assertThat(cause.getMessage()).contains("VarHandle not available");
+    }
+
+    @Test
+    void getJavaVersion_legacyVersion_returns8() {
+        assertThat(Injector.getJavaVersion("1.8.0_321")).isEqualTo(8);
+    }
+
+    @Test
+    void getJavaVersion_modernVersion_returns17() {
+        assertThat(Injector.getJavaVersion("17.0.2")).isEqualTo(17);
+    }
+
+    @Test
+    void getJavaVersion_singleDigitVersion_returns11() {
+        assertThat(Injector.getJavaVersion("11")).isEqualTo(11);
+    }
+
+    @Test
+    void getJavaVersion_malformedVersion_throwsException() {
+        assertThrows(NumberFormatException.class, () -> Injector.getJavaVersion("foo.bar"));
+    }
+
+    @Test
+    void getJavaVersion_shortLegacyVersion_returns8() {
+        assertThat(Injector.getJavaVersion("1.8")).isEqualTo(8);
+    }
+
+    @Test
+    void getJavaVersion_preReleaseVersion_returns17() {
+        assertThat(Injector.getJavaVersion("17-ea")).isEqualTo(17);
     }
 }


### PR DESCRIPTION
This PR adds support of the pre-released Java versions.
Right now, if we have the version "17-ea," the parser of Integer will fail because it's not a valid number. 
We handle cases like 17.0.2, and I think we should handle 17-ea as well. 

Hello @jdereg 
Could you review this PR?